### PR TITLE
Add a licensing and open development page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ Thumbs.db
 
 # Byebug command history
 .byebug_history
+
+# Local preview overlay and tooling artifacts (not used by GitHub Pages)
+_config.local.yml
+.playwright-mcp/

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -44,6 +44,9 @@ menu_settings:
     - title: 'People & Contact'
       url: '/people'
 
+    - title: 'License'
+      url: '/license'
+
 footer_settings:
   footer_tagline: PROTEUS framework for planetary evolution
 

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -7,26 +7,25 @@ image: /assets/img/og-default.jpg
 ---
 
 PROTEUS is fully open source.
-Open source code can be read, run, and improved by anyone, which makes the results that depend on it reproducible and the methods behind them transparent.
+Open source code can be [read, run, and improved by anyone](https://www.gnu.org/philosophy/free-sw.html){:target="_blank" rel="noopener noreferrer"}, which makes the results that depend on it [reproducible](https://www.nature.com/articles/nature10836){:target="_blank" rel="noopener noreferrer"} and the methods behind them transparent.
 For scientific software we consider this a requirement, not an optional extra.
-Every part of the framework is released under an established open source license.
+The [UNESCO open science framework](https://unesdoc.unesco.org/ark:/48223/pf0000387983){:target="_blank" rel="noopener noreferrer"} takes the same view and counts open source software among the pillars of open scientific knowledge.
+Every part of the framework is released under an [established open source license](https://opensource.org/licenses){:target="_blank" rel="noopener noreferrer"}.
 
 We also believe that open development is the best way to build software that lasts.
 PROTEUS grows through collaboration: contributions from research scientists, software engineers, students, and many others across institutions and countries.
-Keeping the code open is what allows that community to form and the science to move forward.
+Keeping the code open is what allows that community to form and [the science to move forward](https://www.nature.com/articles/nchem.1149){:target="_blank" rel="noopener noreferrer"}.
 
-## Open source, without exception
+## Open source, developed in the open
 
-PROTEUS will only ever support and include fully open source code.
+PROTEUS will only ever support and include [fully open source](https://opensource.org/osd){:target="_blank" rel="noopener noreferrer"} code.
 We do not build on closed, proprietary, or source-unavailable components, and we do not plan to.
 If a capability can only be provided by code that is not open, we would rather develop an open alternative than compromise on this principle.
 This keeps the entire pipeline, from input data to published figure, open to inspection.
 
-## Developed in the open
-
-Development of PROTEUS and the modules we maintain happens in public repositories under the [FormingWorlds organisation](https://github.com/FormingWorlds) on GitHub.
+Development of PROTEUS and the modules we maintain happens in public repositories, dominantly under the [FormingWorlds organisation](https://github.com/FormingWorlds){:target="_blank" rel="noopener noreferrer"} on GitHub.
 Issues, code review, and design discussions are public, and anyone can follow the work, report problems, or propose changes.
-Releases are versioned and published, so a published result can state the exact code that produced it.
+Releases are versioned and published, so a published result can state the exact code that produced it, in line with the [FAIR principles for research software](https://www.nature.com/articles/s41597-022-01710-x){:target="_blank" rel="noopener noreferrer"}.
 
 ## A framework of independent modules
 
@@ -61,7 +60,7 @@ Representative examples across the ecosystem:
   </tbody>
 </table>
 
-PROTEUS itself, the coupling framework, is released under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
+PROTEUS itself, the coupling framework, is released under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0){:target="_blank" rel="noopener noreferrer"}.
 
 ## Why PROTEUS uses Apache 2.0
 
@@ -87,24 +86,28 @@ This is why we license the framework, and the modules we maintain, permissively,
 ## Permissive licenses are widely used in scientific software
 
 Permissive licensing is the established choice for the general-purpose scientific software the research community relies on every day.
-Much of the foundational scientific Python stack, including [NumPy](https://numpy.org), [SciPy](https://scipy.org), [pandas](https://pandas.pydata.org), [scikit-learn](https://scikit-learn.org), and [Astropy](https://www.astropy.org), is released under the permissive BSD 3-Clause license, and [Matplotlib](https://matplotlib.org) under its own, equally permissive license.
-Major frameworks such as [TensorFlow](https://www.tensorflow.org) and [JAX](https://github.com/jax-ml/jax) use Apache 2.0, the same license as PROTEUS.
+Much of the foundational scientific Python stack, including [NumPy](https://numpy.org){:target="_blank" rel="noopener noreferrer"}, [SciPy](https://scipy.org){:target="_blank" rel="noopener noreferrer"}, [pandas](https://pandas.pydata.org){:target="_blank" rel="noopener noreferrer"}, [scikit-learn](https://scikit-learn.org){:target="_blank" rel="noopener noreferrer"}, and [Astropy](https://www.astropy.org){:target="_blank" rel="noopener noreferrer"}, is released under the permissive BSD 3-Clause license, and [Matplotlib](https://matplotlib.org){:target="_blank" rel="noopener noreferrer"} under its own, equally permissive license.
+Major frameworks such as [TensorFlow](https://www.tensorflow.org){:target="_blank" rel="noopener noreferrer"} and [JAX](https://github.com/jax-ml/jax){:target="_blank" rel="noopener noreferrer"} use Apache 2.0, the same license as PROTEUS.
 Many of these tools, including Matplotlib, NumPy, and Astropy, grew out of research environments; their permissive licensing removed one obstacle to adoption by companies and institutions alike.
 PROTEUS sits at the framework level, and we license the coupling framework permissively for the same reason.
 Several of the domain-specific solver codes PROTEUS uses are released under copyleft licenses; the next section describes how the framework respects their terms.
 
 ## How Apache 2.0 works alongside GPL-3 modules
 
-Some modules used by PROTEUS are released under the GPL-3.0 license.
-Apache 2.0 and GPL-3.0 are compatible in one direction: Apache 2.0 code may be incorporated into a GPL-3.0 project, and the combined result is then governed by the GPL.
-The reverse does not hold: GPL-3.0 code may not be incorporated into an Apache 2.0 project.
-PROTEUS does not incorporate GPL-3.0 source code into its code base, so this constraint does not arise for PROTEUS itself.
+Some modules used by PROTEUS are released under the [GPL-3.0 license](https://www.gnu.org/licenses/gpl-3.0.html){:target="_blank" rel="noopener noreferrer"}.
+The question that matters here is redistribution: the GPL's strong copyleft obligations attach when a combined work that includes GPL code is distributed, not when programs are run.
+PROTEUS does not redistribute GPL-3.0 code in any form.
+It does not incorporate GPL-3.0 source into its code base, and the PROTEUS package contains only Apache 2.0 code; each module is published separately by its authors as a standalone program.
 
-The framework relies instead on the modular, separately distributed design described above.
-The GPL's strong copyleft obligations attach to the distribution of a combined work.
-Where exactly the boundary of a combined work lies is a long-standing, unresolved question in open source licensing, and there is no settled legal position for the run-time coupling of independent programs.
-We therefore state our reading openly and take a pragmatic view, grounded in the architecture of the framework.
-The PROTEUS package contains only Apache 2.0 code, and each module is published separately by its authors as a standalone program.
+For source code itself, the two licenses are compatible in one direction.
+Apache 2.0 code may be incorporated into a code base distributed under GPL-3.0, and the combined result is then governed by the GPL.
+The reverse does not hold: GPL-3.0 code may not be incorporated into a code base distributed under Apache 2.0.
+Since the PROTEUS code base contains no GPL-3.0 source, this constraint does not arise.
+
+What counts as a combined work is the harder question.
+Where exactly the boundary lies has been debated for as long as open source licensing has existed, and there is no settled legal position for the run-time coupling of independent programs.
+The Free Software Foundation [reads combination broadly](https://www.gnu.org/licenses/gpl-faq.html#GPLStaticVsDynamic){:target="_blank" rel="noopener noreferrer"}; the opposite reading, that running independent programs together does not create a derivative work, [goes back at least two decades](https://www.linuxjournal.com/article/6366){:target="_blank" rel="noopener noreferrer"}.
+We state our reading openly and take a pragmatic view, grounded in the architecture of the framework: the modules are standalone programs, published separately by their authors, and the coupler exchanges boundary conditions with them at run time.
 On that basis we treat the PROTEUS package as not distributing a combined work that includes GPL-3.0 code, and the modules as independent programs, each governed by its own license.
 
 In practice, on this reading: running PROTEUS together with a GPL-3.0 module on your own machine imposes no copyleft obligation on your code, because nothing is distributed.
@@ -121,9 +124,9 @@ We are committed to giving that work proper credit:
 
 - The documentation and code link to the relevant publications and repositories for every module, so the original work is easy to find and cite.
 - Modules that wrap or extend an existing code point to the original project and its papers.
-- We ask users of PROTEUS to cite the manuscripts listed in the [bibliography](https://proteus-framework.org/PROTEUS/Reference/bibliography), to state the code version used, and to include an acknowledgement.
+- We ask users of PROTEUS to cite the manuscripts listed in the [bibliography](https://proteus-framework.org/PROTEUS/Reference/bibliography){:target="_blank" rel="noopener noreferrer"}, to state the code version used, and to include an acknowledgement.
 
-Our full guidance on citation, authorship, and acknowledgement is set out in the [contributing guidelines](https://proteus-framework.org/PROTEUS/Community/CONTRIBUTING).
+Our full guidance on citation, authorship, and acknowledgement is set out in the [contributing guidelines](https://proteus-framework.org/PROTEUS/Community/CONTRIBUTING){:target="_blank" rel="noopener noreferrer"}.
 
 ## Questions and discussion
 
@@ -131,7 +134,7 @@ Licensing in open source is nuanced, and reasonable people read parts of it diff
 We have set out our position here, and we welcome questions, corrections, and discussion.
 If you maintain a code we depend on, are considering using PROTEUS in your own work, or simply want to understand our approach better, please get in touch.
 
-You can reach us through [GitHub Discussions](https://github.com/orgs/FormingWorlds/discussions), open an issue on the relevant repository, or email [proteus_dev@formingworlds.space](mailto:proteus_dev@formingworlds.space).
+You can reach us through [GitHub Discussions](https://github.com/orgs/FormingWorlds/discussions){:target="_blank" rel="noopener noreferrer"}, open an issue on the relevant repository, or email [proteus_dev@formingworlds.space](mailto:proteus_dev@formingworlds.space).
 
 <style>
   table.lic-table {

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -88,7 +88,7 @@ This is why we license the framework, and the modules we maintain, permissively,
 Permissive licensing is the established choice for the general-purpose scientific software the research community relies on every day.
 Much of the foundational scientific Python stack, including [NumPy](https://numpy.org){:target="_blank" rel="noopener noreferrer"}, [SciPy](https://scipy.org){:target="_blank" rel="noopener noreferrer"}, [pandas](https://pandas.pydata.org){:target="_blank" rel="noopener noreferrer"}, [scikit-learn](https://scikit-learn.org){:target="_blank" rel="noopener noreferrer"}, and [Astropy](https://www.astropy.org){:target="_blank" rel="noopener noreferrer"}, is released under the permissive BSD 3-Clause license, and [Matplotlib](https://matplotlib.org){:target="_blank" rel="noopener noreferrer"} under its own, equally permissive license.
 Major frameworks such as [TensorFlow](https://www.tensorflow.org){:target="_blank" rel="noopener noreferrer"} and [JAX](https://github.com/jax-ml/jax){:target="_blank" rel="noopener noreferrer"} use Apache 2.0, the same license as PROTEUS.
-Many of these tools, including Matplotlib, NumPy, and Astropy, grew out of research environments; their permissive licensing removed one obstacle to adoption by companies and institutions alike.
+Many of these tools, including Matplotlib, NumPy, and Astropy, grew out of research environments; their permissive licensing removed one obstacle to adoption by institutions and companies alike.
 PROTEUS sits at the framework level, and we license the coupling framework permissively for the same reason.
 Several of the domain-specific solver codes PROTEUS uses are released under copyleft licenses; the next section describes how the framework respects their terms.
 
@@ -120,7 +120,7 @@ The framework produces more than code.
 Documentation, website text, figures, lookup tables, reference data, and the deposits we publish to archives such as [Zenodo](https://zenodo.org){:target="_blank" rel="noopener noreferrer"} all carry their own licenses, chosen on the same open principle as the software but matched to the kind of material.
 
 We license these assets so that anyone can reuse them, for any purpose including commercially, as long as they give credit.
-That openness is the standard the [Open Definition](https://opendefinition.org){:target="_blank" rel="noopener noreferrer"} sets, and it follows the same reasoning as our permissive software license: figures, tables, and text are most useful when companies, agencies, institutes, and individual researchers can all build on them freely.
+That openness is the standard the [Open Definition](https://opendefinition.org){:target="_blank" rel="noopener noreferrer"} sets, and it follows the same reasoning as our permissive software license: figures, tables, and text are most useful when researchers, universities, institutes, agencies, and companies can all build on them freely.
 A [Creative Commons Attribution license](https://creativecommons.org/licenses/by/4.0/){:target="_blank" rel="noopener noreferrer"} asks only for credit in return, which keeps the work attributed to its authors while leaving it genuinely open to reuse.
 
 We license non-software assets by class, each with one license:

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -32,7 +32,7 @@ The PROTEUS coupler orchestrates the exchange of boundary conditions between whi
 
 Two consequences follow from this design, and both matter for licensing:
 
-- **Modules are optional and swappable.** No single module is required for the framework to function. You can exchange one atmosphere model for another, enable or disable tidal heating, or substitute a different interior model. The framework never depends on any one specific component.
+- **Modules are optional and swappable.** No single module is required for the framework to function. You can exchange one atmosphere model for another, enable or disable tidal heating, or substitute a different interior model.
 - **Modules are published by their own authors.** PROTEUS does not copy module source code into its own code base, and it does not re-host or relicense any module. The PROTEUS package contains only PROTEUS source code. Where a module is a Python package, PROTEUS names it as a dependency that the package manager retrieves from that module's own published release; other modules are fetched from their own repositories at install time. In each case the code comes from the module's own authors, under the module's own license, and is combined with PROTEUS at run time on the user's machine.
 
 Much of the value of PROTEUS lies in this integration work: bringing established codes together, extending them, and in many cases contributing improvements back to the projects they came from.
@@ -67,39 +67,39 @@ In plain terms, a contributor, or the institution that employs them, cannot have
 The license also includes a patent retaliation clause: if a user starts patent litigation alleging that the software infringes one of their patents, the patent licenses that user received under Apache 2.0 are terminated.
 Together these provisions close a gap that MIT and BSD leave open, where a contributor could grant the copyright permissions while making no express promise about their patents. They also shield the project and its community from patent attacks.
 For scientific software this certainty is worth having, because contributors come from many universities, research institutes, and companies, each with their own intellectual property policies and patent portfolios.
-The explicit grant lets everyone who builds on PROTEUS, including other research groups and any downstream industrial or governmental users, rely on the methods implemented in the code without fear of a later patent claim from a contributor.
+The explicit grant lets anyone who builds on PROTEUS use the methods implemented in the code without the risk of a later patent claim from a contributor.
 
 The deeper reason is reach.
 A permissive license keeps the barriers to adoption as low as possible.
 Researchers and institutions can build on PROTEUS, and integrate parts of it into their own pipelines, without being obliged to release their entire surrounding codebase under a copyleft license.
-This matters in practice: some public research institutes, agencies, and companies restrict or prohibit the use of strong-copyleft code precisely because of that obligation.
+Some public research institutes, agencies, and companies restrict or prohibit the use of strong-copyleft code precisely because of that obligation.
 
 There are situations where strong copyleft is the right choice, for example when the explicit goal is to ensure that every downstream user must in turn keep their derived code open.
-For the core PROTEUS framework, whose purpose is to enable science and to be reused as broadly as possible, we judge that maximising reach and minimising friction is more important than enforcing that obligation downstream.
+For the core PROTEUS framework, whose purpose is to enable science and to be reused as broadly as possible, we judge that making PROTEUS easy to adopt and reuse matters more than forcing that obligation on downstream users.
 This is why we prefer Apache 2.0, and more permissive licenses generally, for the framework and for the modules we maintain.
 
 ## How Apache 2.0 works alongside GPL-3 modules
 
 Some modules used by PROTEUS are released under the GPL-3.0 license.
 Apache 2.0 and GPL-3.0 are compatible in one direction: Apache 2.0 code may be incorporated into a GPL-3.0 project, in which case the combined result is governed by the GPL, but GPL-3.0 code may not be incorporated into an Apache 2.0 project.
-PROTEUS does not incorporate GPL-3.0 source code into its own code base, so this one-directional compatibility is respected.
+PROTEUS does not incorporate GPL-3.0 source code into its own code base, so this one-directional constraint does not arise for PROTEUS itself.
 
 The framework relies instead on the modular, separately distributed design described above.
 The GPL's strong copyleft obligations attach to the distribution of a combined work.
 Because the PROTEUS package contains only its own Apache 2.0 code, and each module is published separately by its own authors under its own license, it is our understanding that the PROTEUS package itself does not distribute a combined work that includes GPL-3.0 code.
 The modules remain independent programs, each governed by its own license.
 
-We state this plainly so that anyone reusing the framework understands which terms apply.
 When PROTEUS is run together with a GPL-3.0 module, the combination assembled on your machine is subject to the terms of that module's license, and we treat that license as authoritative for any such run.
 Treating each repository's license as authoritative, and keeping the modules optional and swappable, means the framework can be configured to match the licensing requirements of a project or institution wherever a suitable alternative module is available for each role it needs.
 
-## Permissive licenses are the norm in scientific software
+## Permissive licenses are widely used in scientific software
 
-Permissive licensing is the established choice across the scientific software the research community relies on every day.
+Permissive licensing is the established choice for the general-purpose scientific software the research community relies on every day.
 Much of the foundational scientific Python stack, including [NumPy](https://numpy.org), [SciPy](https://scipy.org), [pandas](https://pandas.pydata.org), [scikit-learn](https://scikit-learn.org), and [Astropy](https://www.astropy.org), is released under the permissive BSD 3-Clause license, and [Matplotlib](https://matplotlib.org) under its own, equally permissive license.
 Major frameworks such as [TensorFlow](https://www.tensorflow.org) and [JAX](https://github.com/jax-ml/jax) use Apache 2.0, the same license as PROTEUS.
 Many of these tools, including Matplotlib, NumPy, and pandas, grew out of academia and became broadly useful in large part because their permissive licensing posed the fewest obstacles to adoption.
-PROTEUS follows the same path.
+Domain-specific solver codes are more often released under copyleft licenses, and PROTEUS builds on several of them while respecting their terms.
+PROTEUS sits at the framework level, and we license the coupling framework permissively for the same reason: to keep the barrier to building on it as low as possible.
 
 ## Credit where it is due
 

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -51,7 +51,7 @@ Representative examples across the ecosystem:
     <tr><td>Apache 2.0</td><td>Permissive (with patent grant)</td><td>PROTEUS, AGNI, CALLIOPE, JANUS, ZEPHYRUS</td></tr>
     <tr><td>MIT</td><td>Permissive</td><td>MORS, Zalmoxis</td></tr>
     <tr><td>BSD 3-Clause</td><td>Permissive</td><td>SOCRATES</td></tr>
-    <tr><td>GPL-3.0</td><td>Strong copyleft</td><td>VULCAN, FastChem, atmodeller, SPIDER</td></tr>
+    <tr><td>GPL-3.0</td><td>Strong copyleft</td><td>VULCAN, FastChem, atmodeller, SPIDER, aragog</td></tr>
   </tbody>
 </table>
 

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -119,10 +119,9 @@ Because the modules are optional and swappable, a simulation can be configured t
 The framework produces more than code.
 Documentation, website text, figures, lookup tables, reference data, and the deposits we publish to archives such as [Zenodo](https://zenodo.org){:target="_blank" rel="noopener noreferrer"} all carry their own licenses, chosen on the same open principle as the software but matched to the kind of material.
 
-We do not place a noncommercial restriction on any of it.
-Such a clause would fail the [Open Definition](https://opendefinition.org){:target="_blank" rel="noopener noreferrer"}, which requires that material may be reused for any purpose, so it would classify our data and figures as closed while the code stays open.
-It would also work against the reach we license the code for: the same companies, agencies, and institutes we want building on the framework could run the code but not reuse the figures and tables around it.
-A [Creative Commons Attribution license](https://creativecommons.org/licenses/by/4.0/){:target="_blank" rel="noopener noreferrer"} already requires credit on every reuse, so it protects attribution without forcing reusers to judge whether their use counts as commercial.
+We license these assets so that anyone can reuse them, for any purpose including commercially, as long as they give credit.
+That openness is the standard the [Open Definition](https://opendefinition.org){:target="_blank" rel="noopener noreferrer"} sets, and it follows the same reasoning as our permissive software license: figures, tables, and text are most useful when companies, agencies, institutes, and individual researchers can all build on them freely.
+A [Creative Commons Attribution license](https://creativecommons.org/licenses/by/4.0/){:target="_blank" rel="noopener noreferrer"} asks only for credit in return, which keeps the work attributed to its authors while leaving it genuinely open to reuse.
 
 We license non-software assets by class, each with one license:
 

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -61,8 +61,13 @@ PROTEUS itself, the coupling framework, is released under the [Apache 2.0 licens
 
 Apache 2.0 is a permissive license.
 It lets anyone use, modify, and redistribute the code, including as part of a larger work under a different license, as long as attribution and the license notice are preserved.
-Beyond the permissions shared by MIT and BSD, Apache 2.0 adds an explicit patent license from contributors to users, together with a patent retaliation clause.
-For scientific software intended to be reused widely, that patent grant provides a layer of protection that the shorter permissive licenses do not.
+Where Apache 2.0 goes further than MIT and BSD is on patents, which those shorter licenses do not address at all.
+Apache 2.0 includes an explicit patent grant: each contributor automatically gives every user a perpetual, worldwide, royalty-free license to any of their own patents that are necessarily infringed by the code they contributed.
+In plain terms, a contributor, or the institution that employs them, cannot have their code accepted into the project and then later assert a patent against the people who use it.
+The license also includes a patent retaliation clause: if a user starts patent litigation alleging that the software infringes one of their patents, the patent licenses that user received under Apache 2.0 are terminated.
+Together these provisions close a gap that MIT and BSD leave open, where a contributor could grant the copyright permissions while quietly retaining patent rights over the same code, and they shield the project and its community from patent attacks.
+For scientific software this certainty is worth having, because contributors come from many universities, research institutes, and companies, each with their own intellectual property policies and patent portfolios.
+The explicit grant lets everyone who builds on PROTEUS, including other research groups and any downstream industrial or governmental users, rely on the methods implemented in the code without fear of a later patent claim from a contributor.
 
 The deeper reason is reach.
 A permissive license keeps the barriers to adoption as low as possible.

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -6,17 +6,38 @@ permalink: /license/
 image: /assets/img/og-default.jpg
 ---
 
-PROTEUS is fully open source.
-Open source code can be [read, run, and improved by anyone](https://www.gnu.org/philosophy/free-sw.html){:target="_blank" rel="noopener noreferrer"}, which makes the results that depend on it [reproducible](https://www.nature.com/articles/nature10836){:target="_blank" rel="noopener noreferrer"} and the methods behind them transparent.
-For scientific software we consider this a requirement, not an optional extra.
-The [UNESCO open science framework](https://unesdoc.unesco.org/ark:/48223/pf0000387983){:target="_blank" rel="noopener noreferrer"} takes the same view and counts open source software among the pillars of open scientific knowledge.
-Every part of the framework is released under an [established open source license](https://opensource.org/licenses){:target="_blank" rel="noopener noreferrer"}.
+## In brief: our core values
 
-We also believe that open development is the best way to build software that lasts.
-PROTEUS grows through collaboration: contributions from research scientists, software engineers, students, and many others across institutions and countries.
-Keeping the code open is what allows that community to form and [the science to move forward](https://www.nature.com/articles/nchem.1149){:target="_blank" rel="noopener noreferrer"}.
+Licensing is a legal subject, and rarely the most exciting part of research.
+We set it out carefully because the right licensing is what lets the law support how we want to do science, rather than stand in its way.
+Two core values shape every choice described on this page:
 
-## Open source, developed in the open
+1. **Open science is the fastest route to progress, and the basis of reproducibility.**
+
+   PROTEUS is fully open source.
+   Open source code can be [read, run, and improved by anyone](https://www.gnu.org/philosophy/free-sw.html){:target="_blank" rel="noopener noreferrer"}, which makes the results that depend on it [reproducible](https://www.nature.com/articles/nature10836){:target="_blank" rel="noopener noreferrer"} and the methods behind them transparent.
+   For scientific software we consider this a requirement, not an optional extra.
+   The [UNESCO open science framework](https://unesdoc.unesco.org/ark:/48223/pf0000387983){:target="_blank" rel="noopener noreferrer"} takes the same view and counts open source software among the pillars of open scientific knowledge.
+   Every part of the framework is released under an [established open source license](https://opensource.org/licenses){:target="_blank" rel="noopener noreferrer"}.
+
+2. **Collaborative science should be as smooth as possible.**
+
+   Open development is the best way to build software that lasts.
+   PROTEUS grows through collaboration: contributions from research scientists, software engineers, students, and many others across institutions and countries.
+   Keeping the code open is what allows that community to form and [the science to move forward](https://www.nature.com/articles/nchem.1149){:target="_blank" rel="noopener noreferrer"}.
+
+The sections below explain how each choice follows from these two values:
+
+- [We build only on fully open source code, and develop it in the open.](#open-development)
+- [PROTEUS couples independent modules, each published and licensed by its own authors.](#modules)
+- [Different components carry different licenses; the repository is always the authoritative source.](#licenses)
+- [We license the framework permissively, under Apache 2.0, for the widest possible reach.](#apache)
+- [Permissive licensing is the established norm for scientific software.](#permissive-norm)
+- [We respect the terms of copyleft modules; running them alongside PROTEUS distributes nothing.](#gpl)
+- [Documentation, data, and figures are openly licensed too; only the logo is reserved.](#assets)
+- [Scientific credit is a separate obligation, and we take it seriously.](#credit)
+
+## Open source, developed in the open {#open-development}
 
 PROTEUS will only ever support and include [fully open source](https://opensource.org/osd){:target="_blank" rel="noopener noreferrer"} code.
 We do not build on closed, proprietary, or source-unavailable components, and we do not plan to.
@@ -27,7 +48,7 @@ Development of PROTEUS and the modules we maintain happens in public repositorie
 Issues, code review, and design discussions are public, and anyone can follow the work, report problems, or propose changes.
 Releases are versioned and published, so a published result can state the exact code that produced it, in line with the [FAIR principles for research software](https://www.nature.com/articles/s41597-022-01710-x){:target="_blank" rel="noopener noreferrer"}.
 
-## A framework of independent modules
+## A framework of independent modules {#modules}
 
 PROTEUS is a coupling framework rather than a single monolithic program.
 The physics is divided across a set of modules, each of which handles one domain: the atmosphere, the mantle, outgassing, photochemistry, escape, stellar evolution, tides, or interior structure.
@@ -42,7 +63,7 @@ One consequence follows from this design, and one is a deliberate choice we have
 
 Much of the value of PROTEUS lies in this integration work: bringing established codes together, extending them, and in many cases contributing improvements back to the projects they came from.
 
-## Licenses across the framework
+## Licenses across the framework {#licenses}
 
 Different components carry different licenses, reflecting the choices of their authors.
 The authoritative license for any component is always the one stated in its repository.
@@ -62,7 +83,7 @@ Representative examples across the ecosystem:
 
 PROTEUS itself, the coupling framework, is released under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0){:target="_blank" rel="noopener noreferrer"}.
 
-## Why PROTEUS uses Apache 2.0
+## Why PROTEUS uses Apache 2.0 {#apache}
 
 Apache 2.0 is a permissive license.
 It lets anyone use, modify, and redistribute the code, including as part of a larger work under a different license, as long as attribution and the license notice are preserved.
@@ -83,7 +104,7 @@ The license also includes a patent retaliation clause: if a user starts patent l
 For scientific software this certainty is worth having, because contributors come from many universities, research institutes, and companies, each with different intellectual property policies and patent portfolios.
 This is why we license the framework, and the modules we maintain, permissively, with Apache 2.0 as our default.
 
-## Permissive licenses are widely used in scientific software
+## Permissive licenses are widely used in scientific software {#permissive-norm}
 
 Permissive licensing is the established choice for the general-purpose scientific software the research community relies on every day.
 Much of the foundational scientific Python stack, including [NumPy](https://numpy.org){:target="_blank" rel="noopener noreferrer"}, [SciPy](https://scipy.org){:target="_blank" rel="noopener noreferrer"}, [pandas](https://pandas.pydata.org){:target="_blank" rel="noopener noreferrer"}, [scikit-learn](https://scikit-learn.org){:target="_blank" rel="noopener noreferrer"}, and [Astropy](https://www.astropy.org){:target="_blank" rel="noopener noreferrer"}, is released under the permissive BSD 3-Clause license, and [Matplotlib](https://matplotlib.org){:target="_blank" rel="noopener noreferrer"} under its own, equally permissive license.
@@ -92,7 +113,7 @@ Many of these tools, including Matplotlib, NumPy, and Astropy, grew out of resea
 PROTEUS sits at the framework level, and we license the coupling framework permissively for the same reason.
 Several of the domain-specific solver codes PROTEUS uses are released under copyleft licenses; the next section describes how the framework respects their terms.
 
-## How Apache 2.0 works alongside GPL-3 modules
+## How Apache 2.0 works alongside GPL-3 modules {#gpl}
 
 Some modules used by PROTEUS are released under the [GPL-3.0 license](https://www.gnu.org/licenses/gpl-3.0.html){:target="_blank" rel="noopener noreferrer"}.
 The question that matters here is redistribution: the GPL's strong copyleft obligations attach when a combined work that includes GPL code is distributed, not when programs are run.
@@ -114,7 +135,7 @@ In practice, on this reading: running PROTEUS together with a GPL-3.0 module on 
 If you redistribute the combination, or modify and redistribute a module, that distribution is governed by the GPL.
 Because the modules are optional and swappable, a simulation can be configured to meet the licensing requirements of a project or institution, provided a suitable alternative module exists for each role.
 
-## Documentation, data, and other non-software assets
+## Documentation, data, and other non-software assets {#assets}
 
 The framework produces more than code.
 Documentation, website text, figures, lookup tables, reference data, and the deposits we publish to archives such as [Zenodo](https://zenodo.org){:target="_blank" rel="noopener noreferrer"} all carry their own licenses, chosen on the same open principle as the software but matched to the kind of material.
@@ -141,7 +162,7 @@ The reserved logo is the only exception: the code, documentation, data, and figu
 An archive deposit that mixes content and data carries CC BY as a whole, with any public-domain data files inside it marked [CC0](https://creativecommons.org/publicdomain/zero/1.0/){:target="_blank" rel="noopener noreferrer"} in the README.
 Where adaptations must stay open under share-alike, [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/){:target="_blank" rel="noopener noreferrer"} is the fallback: it is one-way compatible with GPL-3.0, but it cannot be republished under the plain CC BY terms that many journals use, so figures stay under CC BY to remain publishable there.
 
-## Credit where it is due
+## Credit where it is due {#credit}
 
 A permissive license requires little beyond preserving copyright and license notices; it says nothing about the scientific credit owed to the people who wrote the code.
 We treat that credit as a separate and serious obligation, fully independent of licensing.

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -117,13 +117,12 @@ Because the modules are optional and swappable, a simulation can be configured t
 ## Documentation, data, and other non-software assets
 
 The framework produces more than code.
-It also produces documentation, website text, figures, lookup tables, reference data, and the deposits we publish to archives such as [Zenodo](https://zenodo.org){:target="_blank" rel="noopener noreferrer"}.
-These carry their own licenses, chosen on the same open principle as the software but matched to the kind of material.
+Documentation, website text, figures, lookup tables, reference data, and the deposits we publish to archives such as [Zenodo](https://zenodo.org){:target="_blank" rel="noopener noreferrer"} all carry their own licenses, chosen on the same open principle as the software but matched to the kind of material.
 
 We do not place a noncommercial restriction on any of it.
-Such a clause would fail the [Open Definition](https://opendefinition.org){:target="_blank" rel="noopener noreferrer"}, which requires that material may be reused for any purpose, so it would classify our data and figures as closed while the code is open.
-It would also undercut the reach we license the code for: the same companies, agencies, and institutes we want building on the framework would be free to run the code but restricted from reusing the figures and tables around it.
-A [Creative Commons Attribution license](https://creativecommons.org/licenses/by/4.0/){:target="_blank" rel="noopener noreferrer"} already requires credit on every reuse, so it protects attribution without the legal-review friction that "noncommercial" introduces.
+Such a clause would fail the [Open Definition](https://opendefinition.org){:target="_blank" rel="noopener noreferrer"}, which requires that material may be reused for any purpose, so it would classify our data and figures as closed while the code stays open.
+It would also work against the reach we license the code for: the same companies, agencies, and institutes we want building on the framework could run the code but not reuse the figures and tables around it.
+A [Creative Commons Attribution license](https://creativecommons.org/licenses/by/4.0/){:target="_blank" rel="noopener noreferrer"} already requires credit on every reuse, so it protects attribution without forcing reusers to judge whether their use counts as commercial.
 
 We license non-software assets by class, each with one license:
 
@@ -132,14 +131,16 @@ We license non-software assets by class, each with one license:
     <tr><th>Asset</th><th>License</th><th>What it means</th></tr>
   </thead>
   <tbody>
-    <tr><td>Documentation, website text, figures</td><td>CC BY 4.0</td><td>Free to reuse and adapt with attribution. Compatible with the CC BY terms used by open access journals, so a figure can move between our pages and the published literature without a rights conflict. The content analogue of the permissive license we use for code.</td></tr>
-    <tr><td>Lookup tables, reference data, archive deposits</td><td>CC0 1.0</td><td>Placed in the public domain, so combined datasets need not carry a growing list of required credits. Citation is handled the way science already handles it, through community norms and our credit guidance. Major data repositories require or default to CC0, and research funders accept it for deposited data.</td></tr>
-    <tr><td>Logos and brand marks</td><td>Reserved</td><td>Not openly licensed. We do not want forks or unrelated products shipping under the project's visual identity, which established projects guard through trademark policy. We hold no registered marks, so the artwork stays under reserved copyright with a short usage note.</td></tr>
+    <tr><td>Documentation, website text, figures</td><td>CC BY 4.0</td><td>Free to reuse and adapt with attribution. Many open access journals publish under the same CC BY terms, so a figure can move between our pages and the published literature, with attribution travelling alongside it. It plays the same role for content that our permissive license plays for code.</td></tr>
+    <tr><td>Lookup tables and reference data</td><td>CC0 1.0</td><td>Dedicated to the public domain as far as the law allows, so combined datasets need not carry a growing list of required credits. Citation follows the norms science already uses, supported by our credit guidance. Several major data repositories require or default to CC0 (Dryad requires it; figshare and Dataverse default to it), and funders such as Horizon Europe accept it for deposited data.</td></tr>
+    <tr><td>Logos and brand marks</td><td>Reserved</td><td>Not openly licensed. We do not want forks or unrelated products shipping under the project's visual identity, which established projects guard through trademark policy. We hold no registered trademarks, so instead of a formal policy we keep the artwork under reserved copyright with a short usage note.</td></tr>
   </tbody>
 </table>
 
-A mixed archive deposit carries CC BY for the deposit as a whole, with any public-domain data files marked [CC0](https://creativecommons.org/publicdomain/zero/1.0/){:target="_blank" rel="noopener noreferrer"} in its README.
-Where share-alike is specifically wanted, [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/){:target="_blank" rel="noopener noreferrer"} is the fallback: it keeps adaptations open and is one-way compatible with GPL-3.0, at the cost of the journal compatibility above, so figures would still stay under CC BY.
+The reserved logo is the only exception: the code, documentation, data, and figures are all openly licensed.
+
+An archive deposit that mixes content and data carries CC BY as a whole, with any public-domain data files inside it marked [CC0](https://creativecommons.org/publicdomain/zero/1.0/){:target="_blank" rel="noopener noreferrer"} in the README.
+Where adaptations must stay open under share-alike, [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/){:target="_blank" rel="noopener noreferrer"} is the fallback: it is one-way compatible with GPL-3.0, but it cannot be republished under the plain CC BY terms that many journals use, so figures stay under CC BY to remain publishable there.
 
 ## Credit where it is due
 

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -6,41 +6,47 @@ permalink: /license/
 image: /assets/img/og-default.jpg
 ---
 
-PROTEUS is built on the conviction that science is strongest when it is open.
-Open source code can be read, checked, run, adapted, and improved by anyone, which makes the results that depend on it reproducible and the methods behind them transparent.
-We see this not as an optional extra but as a basic requirement for software that sits at the heart of scientific work.
-Every part of the framework is therefore released under a recognised open source license.
+PROTEUS is fully open source.
+Open source code can be read, run, and improved by anyone, which makes the results that depend on it reproducible and the methods behind them transparent.
+For scientific software we consider this a requirement, not an optional extra.
+Every part of the framework is released under an established open source license.
 
 We also believe that open development is the best way to build software that lasts.
 PROTEUS grows through collaboration: contributions from research scientists, software engineers, students, and many others across institutions and countries.
-Keeping the code open, and keeping the barriers to using and contributing to it low, is what allows that community to form and the science to move forward.
+Keeping the code open is what allows that community to form and the science to move forward.
 
 ## Open source, without exception
 
 PROTEUS will only ever support and include fully open source code.
 We do not build on closed, proprietary, or source-unavailable components, and we do not plan to.
 If a capability can only be provided by code that is not open, we would rather develop an open alternative than compromise on this principle.
-This keeps the entire pipeline, from input data to published figure, inspectable end to end.
+This keeps the entire pipeline, from input data to published figure, open to inspection.
+
+## Developed in the open
+
+Development of PROTEUS and the modules we maintain happens in public repositories under the [FormingWorlds organisation](https://github.com/FormingWorlds) on GitHub.
+Issues, code review, and design discussions are public, and anyone can follow the work, report problems, or propose changes.
+Releases are versioned and published, so a published result can state the exact code that produced it.
 
 ## A framework of independent modules
 
 PROTEUS is a coupling framework rather than a single monolithic program.
 The physics is divided across a set of modules, each of which handles one domain: the atmosphere, the mantle, outgassing, photochemistry, escape, stellar evolution, tides, or interior structure.
-Each module is a complete, standalone program in its own right.
-It can be developed, tested, run, and published independently, and it lives in its own repository under its own license.
+Each module is a complete, standalone program.
+It can be developed, tested, run, and published independently, and it lives in a separate repository under a license chosen by its authors.
 The PROTEUS coupler orchestrates the exchange of boundary conditions between whichever modules are selected for a given simulation.
 
-Two consequences follow from this design, and both matter for licensing:
+One consequence follows from this design, and one is a deliberate choice we have made about distribution. Both matter for licensing:
 
 - **Modules are optional and swappable.** No single module is required for the framework to function. You can exchange one atmosphere model for another, enable or disable tidal heating, or substitute a different interior model.
-- **Modules are published by their own authors.** PROTEUS does not copy module source code into its own code base, and it does not re-host or relicense any module. The PROTEUS package contains only PROTEUS source code. Where a module is a Python package, PROTEUS names it as a dependency that the package manager retrieves from that module's own published release; other modules are fetched from their own repositories at install time. In each case the code comes from the module's own authors, under the module's own license, and is combined with PROTEUS at run time on the user's machine.
+- **Modules are published by their own authors.** PROTEUS does not copy module source code into its code base, and it does not relicense any module. The PROTEUS package contains only PROTEUS source code. Where a module is a Python package, PROTEUS names it as a dependency that the package manager retrieves from the module's published release. Other modules are fetched at install time, in some cases from FormingWorlds-maintained forks of the upstream project, always under the upstream license. In each case the code is combined with PROTEUS at run time on the user's machine.
 
 Much of the value of PROTEUS lies in this integration work: bringing established codes together, extending them, and in many cases contributing improvements back to the projects they came from.
 
 ## Licenses across the framework
 
 Different components carry different licenses, reflecting the choices of their authors.
-The authoritative license for any component is always the one stated in its own repository.
+The authoritative license for any component is always the one stated in its repository.
 Representative examples across the ecosystem:
 
 <table class="lic-table">
@@ -61,57 +67,59 @@ PROTEUS itself, the coupling framework, is released under the [Apache 2.0 licens
 
 Apache 2.0 is a permissive license.
 It lets anyone use, modify, and redistribute the code, including as part of a larger work under a different license, as long as attribution and the license notice are preserved.
-Where Apache 2.0 goes further than MIT and BSD is on patents, which those shorter licenses do not cover with an explicit grant.
-Apache 2.0 includes an explicit patent grant: each contributor automatically gives every user a perpetual, worldwide, royalty-free license to any of their own patents that are necessarily infringed by the code they contributed, whether on its own or in combination with the rest of the project.
-In plain terms, a contributor, or the institution that employs them, cannot have their code accepted into the project and then later assert a patent against the people who use it.
-The license also includes a patent retaliation clause: if a user starts patent litigation alleging that the software infringes one of their patents, the patent licenses that user received under Apache 2.0 are terminated.
-Together these provisions close a gap that MIT and BSD leave open, where a contributor could grant the copyright permissions while making no express promise about their patents. They also shield the project and its community from patent attacks.
-For scientific software this certainty is worth having, because contributors come from many universities, research institutes, and companies, each with their own intellectual property policies and patent portfolios.
-The explicit grant lets anyone who builds on PROTEUS use the methods implemented in the code without the risk of a later patent claim from a contributor.
 
-The deeper reason is reach.
+Our main reason is reach.
 A permissive license keeps the barriers to adoption as low as possible.
-Researchers and institutions can build on PROTEUS, and integrate parts of it into their own pipelines, without being obliged to release their entire surrounding codebase under a copyleft license.
-Some public research institutes, agencies, and companies restrict or prohibit the use of strong-copyleft code precisely because of that obligation.
+The alternative, a copyleft license, requires that derived works be released under the same terms.
+Researchers and institutions can build on PROTEUS, and integrate parts of it into their pipelines, without taking on that obligation for the surrounding code.
+Some public research institutes, agencies, and companies restrict or prohibit the use of strong-copyleft code for precisely this reason.
 
 There are situations where strong copyleft is the right choice, for example when the explicit goal is to ensure that every downstream user must in turn keep their derived code open.
-For the core PROTEUS framework, whose purpose is to enable science and to be reused as broadly as possible, we judge that making PROTEUS easy to adopt and reuse matters more than forcing that obligation on downstream users.
-This is why we prefer Apache 2.0, and more permissive licenses generally, for the framework and for the modules we maintain.
+For the core PROTEUS framework, whose purpose is to enable science as broadly as possible, we judge that ease of adoption matters more than that guarantee.
 
-## How Apache 2.0 works alongside GPL-3 modules
-
-Some modules used by PROTEUS are released under the GPL-3.0 license.
-Apache 2.0 and GPL-3.0 are compatible in one direction: Apache 2.0 code may be incorporated into a GPL-3.0 project, in which case the combined result is governed by the GPL, but GPL-3.0 code may not be incorporated into an Apache 2.0 project.
-PROTEUS does not incorporate GPL-3.0 source code into its own code base, so this one-directional constraint does not arise for PROTEUS itself.
-
-The framework relies instead on the modular, separately distributed design described above.
-The GPL's strong copyleft obligations attach to the distribution of a combined work.
-Because the PROTEUS package contains only its own Apache 2.0 code, and each module is published separately by its own authors under its own license, it is our understanding that the PROTEUS package itself does not distribute a combined work that includes GPL-3.0 code.
-The modules remain independent programs, each governed by its own license.
-
-When PROTEUS is run together with a GPL-3.0 module, the combination assembled on your machine is subject to the terms of that module's license, and we treat that license as authoritative for any such run.
-Treating each repository's license as authoritative, and keeping the modules optional and swappable, means the framework can be configured to match the licensing requirements of a project or institution wherever a suitable alternative module is available for each role it needs.
+Among permissive licenses, we choose Apache 2.0 over MIT and BSD because of patents, which those shorter licenses do not cover with an explicit grant.
+Under Apache 2.0, each contributor automatically gives every user a perpetual, worldwide, royalty-free license to any of their patents that are necessarily infringed by the code they contributed.
+The grant covers that code on its own and in combination with the rest of the project.
+The license also includes a patent retaliation clause: if a user starts patent litigation alleging that the software infringes one of their patents, the patent licenses that user received under Apache 2.0 are terminated.
+For scientific software this certainty is worth having, because contributors come from many universities, research institutes, and companies, each with different intellectual property policies and patent portfolios.
+This is why we license the framework, and the modules we maintain, permissively, with Apache 2.0 as our default.
 
 ## Permissive licenses are widely used in scientific software
 
 Permissive licensing is the established choice for the general-purpose scientific software the research community relies on every day.
 Much of the foundational scientific Python stack, including [NumPy](https://numpy.org), [SciPy](https://scipy.org), [pandas](https://pandas.pydata.org), [scikit-learn](https://scikit-learn.org), and [Astropy](https://www.astropy.org), is released under the permissive BSD 3-Clause license, and [Matplotlib](https://matplotlib.org) under its own, equally permissive license.
 Major frameworks such as [TensorFlow](https://www.tensorflow.org) and [JAX](https://github.com/jax-ml/jax) use Apache 2.0, the same license as PROTEUS.
-Many of these tools, including Matplotlib, NumPy, and pandas, grew out of academia and became broadly useful in large part because their permissive licensing posed the fewest obstacles to adoption.
-Domain-specific solver codes are more often released under copyleft licenses, and PROTEUS builds on several of them while respecting their terms.
-PROTEUS sits at the framework level, and we license the coupling framework permissively for the same reason: to keep the barrier to building on it as low as possible.
+Many of these tools, including Matplotlib, NumPy, and Astropy, grew out of research environments; their permissive licensing removed one obstacle to adoption by companies and institutions alike.
+PROTEUS sits at the framework level, and we license the coupling framework permissively for the same reason.
+Several of the domain-specific solver codes PROTEUS uses are released under copyleft licenses; the next section describes how the framework respects their terms.
+
+## How Apache 2.0 works alongside GPL-3 modules
+
+Some modules used by PROTEUS are released under the GPL-3.0 license.
+Apache 2.0 and GPL-3.0 are compatible in one direction: Apache 2.0 code may be incorporated into a GPL-3.0 project, and the combined result is then governed by the GPL.
+The reverse does not hold: GPL-3.0 code may not be incorporated into an Apache 2.0 project.
+PROTEUS does not incorporate GPL-3.0 source code into its code base, so this constraint does not arise for PROTEUS itself.
+
+The framework relies instead on the modular, separately distributed design described above.
+The GPL's strong copyleft obligations attach to the distribution of a combined work.
+The PROTEUS package contains only Apache 2.0 code, and each module is published separately by its authors.
+It is our understanding that the PROTEUS package therefore does not distribute a combined work that includes GPL-3.0 code, and that the modules remain independent programs, each governed by its own license.
+
+In practice: running PROTEUS together with a GPL-3.0 module on your own machine imposes no copyleft obligation on your code, because nothing is distributed.
+If you redistribute the combination, or modify and redistribute a module, that distribution is governed by the GPL.
+On this understanding, and because the modules are optional and swappable, a simulation can be configured to meet the licensing requirements of a project or institution, provided a suitable alternative module exists for each role.
 
 ## Credit where it is due
 
-A permissive license sets out how code may be used; it says nothing about the credit owed to the people who wrote it.
-We treat scientific credit as a separate and serious obligation, fully independent of licensing.
-PROTEUS exists because of the work of the wider community, and many of its modules build directly on codes developed and published by others.
+A permissive license requires little beyond preserving copyright and license notices; it says nothing about the scientific credit owed to the people who wrote the code.
+We treat that credit as a separate and serious obligation, fully independent of licensing.
+PROTEUS exists because of the work of the wider community, and many of its modules extend codes developed and published by others.
 
 We are committed to giving that work proper credit:
 
 - The documentation and code link to the relevant publications and repositories for every module, so the original work is easy to find and cite.
 - Modules that wrap or extend an existing code point to the original project and its papers.
-- Users of PROTEUS are asked to cite the manuscripts listed in the [bibliography](https://proteus-framework.org/PROTEUS/Reference/bibliography), to state the code version used, and to include an acknowledgement.
+- We ask users of PROTEUS to cite the manuscripts listed in the [bibliography](https://proteus-framework.org/PROTEUS/Reference/bibliography), to state the code version used, and to include an acknowledgement.
 
 Our full guidance on citation, authorship, and acknowledgement is set out in the [contributing guidelines](https://proteus-framework.org/PROTEUS/Community/CONTRIBUTING).
 
@@ -119,10 +127,9 @@ Our full guidance on citation, authorship, and acknowledgement is set out in the
 
 Licensing in open source is nuanced, and reasonable people read parts of it differently.
 We have set out our position here, and we welcome questions, corrections, and discussion.
-If you maintain a code we build on, are considering building on PROTEUS, or simply want to understand our approach better, please get in touch.
+If you maintain a code we depend on, are considering using PROTEUS in your own work, or simply want to understand our approach better, please get in touch.
 
 You can reach us through [GitHub Discussions](https://github.com/orgs/FormingWorlds/discussions), open an issue on the relevant repository, or email [proteus_dev@formingworlds.space](mailto:proteus_dev@formingworlds.space).
-We are always happy to talk this through.
 
 <style>
   table.lic-table {

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -102,12 +102,14 @@ PROTEUS does not incorporate GPL-3.0 source code into its code base, so this con
 
 The framework relies instead on the modular, separately distributed design described above.
 The GPL's strong copyleft obligations attach to the distribution of a combined work.
-The PROTEUS package contains only Apache 2.0 code, and each module is published separately by its authors.
-It is our understanding that the PROTEUS package therefore does not distribute a combined work that includes GPL-3.0 code, and that the modules remain independent programs, each governed by its own license.
+Where exactly the boundary of a combined work lies is a long-standing, unresolved question in open source licensing, and there is no settled legal position for the run-time coupling of independent programs.
+We therefore state our reading openly and take a pragmatic view, grounded in the architecture of the framework.
+The PROTEUS package contains only Apache 2.0 code, and each module is published separately by its authors as a standalone program.
+On that basis we treat the PROTEUS package as not distributing a combined work that includes GPL-3.0 code, and the modules as independent programs, each governed by its own license.
 
-In practice: running PROTEUS together with a GPL-3.0 module on your own machine imposes no copyleft obligation on your code, because nothing is distributed.
+In practice, on this reading: running PROTEUS together with a GPL-3.0 module on your own machine imposes no copyleft obligation on your code, because nothing is distributed.
 If you redistribute the combination, or modify and redistribute a module, that distribution is governed by the GPL.
-On this understanding, and because the modules are optional and swappable, a simulation can be configured to meet the licensing requirements of a project or institution, provided a suitable alternative module exists for each role.
+Because the modules are optional and swappable, a simulation can be configured to meet the licensing requirements of a project or institution, provided a suitable alternative module exists for each role.
 
 ## Credit where it is due
 

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -114,6 +114,33 @@ In practice, on this reading: running PROTEUS together with a GPL-3.0 module on 
 If you redistribute the combination, or modify and redistribute a module, that distribution is governed by the GPL.
 Because the modules are optional and swappable, a simulation can be configured to meet the licensing requirements of a project or institution, provided a suitable alternative module exists for each role.
 
+## Documentation, data, and other non-software assets
+
+The framework produces more than code.
+It also produces documentation, website text, figures, lookup tables, reference data, and the deposits we publish to archives such as [Zenodo](https://zenodo.org){:target="_blank" rel="noopener noreferrer"}.
+These carry their own licenses, chosen on the same open principle as the software but matched to the kind of material.
+
+We do not place a noncommercial restriction on any of it.
+Such a clause would fail the [Open Definition](https://opendefinition.org){:target="_blank" rel="noopener noreferrer"}, which requires that material may be reused for any purpose, so it would classify our data and figures as closed while the code is open.
+It would also undercut the reach we license the code for: the same companies, agencies, and institutes we want building on the framework would be free to run the code but restricted from reusing the figures and tables around it.
+A [Creative Commons Attribution license](https://creativecommons.org/licenses/by/4.0/){:target="_blank" rel="noopener noreferrer"} already requires credit on every reuse, so it protects attribution without the legal-review friction that "noncommercial" introduces.
+
+We license non-software assets by class, each with one license:
+
+<table class="lic-table">
+  <thead>
+    <tr><th>Asset</th><th>License</th><th>What it means</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Documentation, website text, figures</td><td>CC BY 4.0</td><td>Free to reuse and adapt with attribution. Compatible with the CC BY terms used by open access journals, so a figure can move between our pages and the published literature without a rights conflict. The content analogue of the permissive license we use for code.</td></tr>
+    <tr><td>Lookup tables, reference data, archive deposits</td><td>CC0 1.0</td><td>Placed in the public domain, so combined datasets need not carry a growing list of required credits. Citation is handled the way science already handles it, through community norms and our credit guidance. Major data repositories require or default to CC0, and research funders accept it for deposited data.</td></tr>
+    <tr><td>Logos and brand marks</td><td>Reserved</td><td>Not openly licensed. We do not want forks or unrelated products shipping under the project's visual identity, which established projects guard through trademark policy. We hold no registered marks, so the artwork stays under reserved copyright with a short usage note.</td></tr>
+  </tbody>
+</table>
+
+A mixed archive deposit carries CC BY for the deposit as a whole, with any public-domain data files marked [CC0](https://creativecommons.org/publicdomain/zero/1.0/){:target="_blank" rel="noopener noreferrer"} in its README.
+Where share-alike is specifically wanted, [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/){:target="_blank" rel="noopener noreferrer"} is the fallback: it keeps adaptations open and is one-way compatible with GPL-3.0, at the cost of the journal compatibility above, so figures would still stay under CC BY.
+
 ## Credit where it is due
 
 A permissive license requires little beyond preserving copyright and license notices; it says nothing about the scientific credit owed to the people who wrote the code.

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -33,7 +33,7 @@ The PROTEUS coupler orchestrates the exchange of boundary conditions between whi
 Two consequences follow from this design, and both matter for licensing:
 
 - **Modules are optional and swappable.** No single module is required for the framework to function. You can exchange one atmosphere model for another, enable or disable tidal heating, or substitute a different interior model. The framework never depends on any one specific component.
-- **Modules are distributed separately.** PROTEUS does not bundle or redistribute the modules. The released PROTEUS package contains only PROTEUS source code. Each module is obtained directly by the user from its own repository, installed alongside PROTEUS, and combined at run time on the user's own machine.
+- **Modules are published by their own authors.** PROTEUS does not copy module source code into its own code base, and it does not re-host or relicense any module. The PROTEUS package contains only PROTEUS source code. Where a module is a Python package, PROTEUS names it as a dependency that the package manager retrieves from that module's own published release; other modules are fetched from their own repositories at install time. In each case the code comes from the module's own authors, under the module's own license, and is combined with PROTEUS at run time on the user's machine.
 
 Much of the value of PROTEUS lies in this integration work: bringing established codes together, extending them, and in many cases contributing improvements back to the projects they came from.
 
@@ -61,11 +61,11 @@ PROTEUS itself, the coupling framework, is released under the [Apache 2.0 licens
 
 Apache 2.0 is a permissive license.
 It lets anyone use, modify, and redistribute the code, including as part of a larger work under a different license, as long as attribution and the license notice are preserved.
-Where Apache 2.0 goes further than MIT and BSD is on patents, which those shorter licenses do not address at all.
-Apache 2.0 includes an explicit patent grant: each contributor automatically gives every user a perpetual, worldwide, royalty-free license to any of their own patents that are necessarily infringed by the code they contributed.
+Where Apache 2.0 goes further than MIT and BSD is on patents, which those shorter licenses do not cover with an explicit grant.
+Apache 2.0 includes an explicit patent grant: each contributor automatically gives every user a perpetual, worldwide, royalty-free license to any of their own patents that are necessarily infringed by the code they contributed, whether on its own or in combination with the rest of the project.
 In plain terms, a contributor, or the institution that employs them, cannot have their code accepted into the project and then later assert a patent against the people who use it.
 The license also includes a patent retaliation clause: if a user starts patent litigation alleging that the software infringes one of their patents, the patent licenses that user received under Apache 2.0 are terminated.
-Together these provisions close a gap that MIT and BSD leave open, where a contributor could grant the copyright permissions while quietly retaining patent rights over the same code, and they shield the project and its community from patent attacks.
+Together these provisions close a gap that MIT and BSD leave open, where a contributor could grant the copyright permissions while making no express promise about their patents. They also shield the project and its community from patent attacks.
 For scientific software this certainty is worth having, because contributors come from many universities, research institutes, and companies, each with their own intellectual property policies and patent portfolios.
 The explicit grant lets everyone who builds on PROTEUS, including other research groups and any downstream industrial or governmental users, rely on the methods implemented in the code without fear of a later patent claim from a contributor.
 
@@ -73,7 +73,6 @@ The deeper reason is reach.
 A permissive license keeps the barriers to adoption as low as possible.
 Researchers and institutions can build on PROTEUS, and integrate parts of it into their own pipelines, without being obliged to release their entire surrounding codebase under a copyleft license.
 This matters in practice: some public research institutes, agencies, and companies restrict or prohibit the use of strong-copyleft code precisely because of that obligation.
-A permissive license keeps the door open to the widest possible set of collaborators.
 
 There are situations where strong copyleft is the right choice, for example when the explicit goal is to ensure that every downstream user must in turn keep their derived code open.
 For the core PROTEUS framework, whose purpose is to enable science and to be reused as broadly as possible, we judge that maximising reach and minimising friction is more important than enforcing that obligation downstream.
@@ -87,17 +86,17 @@ PROTEUS does not incorporate GPL-3.0 source code into its own code base, so this
 
 The framework relies instead on the modular, separately distributed design described above.
 The GPL's strong copyleft obligations attach to the distribution of a combined work.
-Because PROTEUS distributes only its own Apache 2.0 code, and each module is distributed separately by its own authors and obtained directly by the user, PROTEUS itself does not distribute a combined work that includes GPL-3.0 code.
+Because the PROTEUS package contains only its own Apache 2.0 code, and each module is published separately by its own authors under its own license, it is our understanding that the PROTEUS package itself does not distribute a combined work that includes GPL-3.0 code.
 The modules remain independent programs, each governed by its own license.
 
 We state this plainly so that anyone reusing the framework understands which terms apply.
-When PROTEUS is run together with a GPL-3.0 module, the combined work assembled on your machine is, in the strictest reading, subject to the terms of that module's license.
-Treating each repository's license as authoritative, and keeping the modules optional and swappable, means the framework can always be configured to match the licensing requirements of a given project or institution.
+When PROTEUS is run together with a GPL-3.0 module, the combination assembled on your machine is subject to the terms of that module's license, and we treat that license as authoritative for any such run.
+Treating each repository's license as authoritative, and keeping the modules optional and swappable, means the framework can be configured to match the licensing requirements of a project or institution wherever a suitable alternative module is available for each role it needs.
 
 ## Permissive licenses are the norm in scientific software
 
 Permissive licensing is the established choice across the scientific software the research community relies on every day.
-The foundational scientific Python stack, including [NumPy](https://numpy.org), [SciPy](https://scipy.org), [pandas](https://pandas.pydata.org), [Matplotlib](https://matplotlib.org), [scikit-learn](https://scikit-learn.org), and [Astropy](https://www.astropy.org), is released under the permissive BSD 3-Clause license.
+Much of the foundational scientific Python stack, including [NumPy](https://numpy.org), [SciPy](https://scipy.org), [pandas](https://pandas.pydata.org), [scikit-learn](https://scikit-learn.org), and [Astropy](https://www.astropy.org), is released under the permissive BSD 3-Clause license, and [Matplotlib](https://matplotlib.org) under its own, equally permissive license.
 Major frameworks such as [TensorFlow](https://www.tensorflow.org) and [JAX](https://github.com/jax-ml/jax) use Apache 2.0, the same license as PROTEUS.
 Many of these tools, including Matplotlib, NumPy, and pandas, grew out of academia and became broadly useful in large part because their permissive licensing posed the fewest obstacles to adoption.
 PROTEUS follows the same path.
@@ -112,14 +111,14 @@ We are committed to giving that work proper credit:
 
 - The documentation and code link to the relevant publications and repositories for every module, so the original work is easy to find and cite.
 - Modules that wrap or extend an existing code point to the original project and its papers.
-- Users of PROTEUS are asked to cite the manuscripts listed in the [bibliography](https://proteus-framework.org/PROTEUS/Reference/bibliography/), to state the code version used, and to include an acknowledgement.
+- Users of PROTEUS are asked to cite the manuscripts listed in the [bibliography](https://proteus-framework.org/PROTEUS/Reference/bibliography), to state the code version used, and to include an acknowledgement.
 
-Our full guidance on citation, authorship, and acknowledgement is set out in the [contributing guidelines](https://proteus-framework.org/PROTEUS/Community/CONTRIBUTING/).
+Our full guidance on citation, authorship, and acknowledgement is set out in the [contributing guidelines](https://proteus-framework.org/PROTEUS/Community/CONTRIBUTING).
 
 ## Questions and discussion
 
-Licensing in open source is a genuinely nuanced area, and reasonable people interpret parts of it differently.
-We have set out our position here in the spirit of transparency, and we welcome questions, corrections, and discussion.
+Licensing in open source is nuanced, and reasonable people read parts of it differently.
+We have set out our position here, and we welcome questions, corrections, and discussion.
 If you maintain a code we build on, are considering building on PROTEUS, or simply want to understand our approach better, please get in touch.
 
 You can reach us through [GitHub Discussions](https://github.com/orgs/FormingWorlds/discussions), open an issue on the relevant repository, or email [proteus_dev@formingworlds.space](mailto:proteus_dev@formingworlds.space).

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -1,0 +1,146 @@
+---
+title: Licensing and open development
+subtitle: How PROTEUS and its modules are licensed, and our commitment to open, reproducible science
+description: "The licensing philosophy of the PROTEUS framework: fully open source, modular and independently licensed components, why we use Apache 2.0, how it works alongside GPL-3 modules, and our commitment to crediting the developers of the code we build on."
+permalink: /license/
+image: /assets/img/og-default.jpg
+---
+
+PROTEUS is built on the conviction that science is strongest when it is open.
+Open source code can be read, checked, run, adapted, and improved by anyone, which makes the results that depend on it reproducible and the methods behind them transparent.
+We see this not as an optional extra but as a basic requirement for software that sits at the heart of scientific work.
+Every part of the framework is therefore released under a recognised open source license.
+
+We also believe that open development is the best way to build software that lasts.
+PROTEUS grows through collaboration: contributions from research scientists, software engineers, students, and many others across institutions and countries.
+Keeping the code open, and keeping the barriers to using and contributing to it low, is what allows that community to form and the science to move forward.
+
+## Open source, without exception
+
+PROTEUS will only ever support and include fully open source code.
+We do not build on closed, proprietary, or source-unavailable components, and we do not plan to.
+If a capability can only be provided by code that is not open, we would rather develop an open alternative than compromise on this principle.
+This keeps the entire pipeline, from input data to published figure, inspectable end to end.
+
+## A framework of independent modules
+
+PROTEUS is a coupling framework rather than a single monolithic program.
+The physics is divided across a set of modules, each of which handles one domain: the atmosphere, the mantle, outgassing, photochemistry, escape, stellar evolution, tides, or interior structure.
+Each module is a complete, standalone program in its own right.
+It can be developed, tested, run, and published independently, and it lives in its own repository under its own license.
+The PROTEUS coupler orchestrates the exchange of boundary conditions between whichever modules are selected for a given simulation.
+
+Two consequences follow from this design, and both matter for licensing:
+
+- **Modules are optional and swappable.** No single module is required for the framework to function. You can exchange one atmosphere model for another, enable or disable tidal heating, or substitute a different interior model. The framework never depends on any one specific component.
+- **Modules are distributed separately.** PROTEUS does not bundle or redistribute the modules. The released PROTEUS package contains only PROTEUS source code. Each module is obtained directly by the user from its own repository, installed alongside PROTEUS, and combined at run time on the user's own machine.
+
+Much of the value of PROTEUS lies in this integration work: bringing established codes together, extending them, and in many cases contributing improvements back to the projects they came from.
+
+## Licenses across the framework
+
+Different components carry different licenses, reflecting the choices of their authors.
+The authoritative license for any component is always the one stated in its own repository.
+Representative examples across the ecosystem:
+
+<table class="lic-table">
+  <thead>
+    <tr><th>License</th><th>Type</th><th>Examples</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Apache 2.0</td><td>Permissive (with patent grant)</td><td>PROTEUS, AGNI, CALLIOPE, JANUS, ZEPHYRUS</td></tr>
+    <tr><td>MIT</td><td>Permissive</td><td>MORS, Zalmoxis</td></tr>
+    <tr><td>BSD 3-Clause</td><td>Permissive</td><td>SOCRATES</td></tr>
+    <tr><td>GPL-3.0</td><td>Strong copyleft</td><td>VULCAN, FastChem, atmodeller, SPIDER</td></tr>
+  </tbody>
+</table>
+
+PROTEUS itself, the coupling framework, is released under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Why PROTEUS uses Apache 2.0
+
+Apache 2.0 is a permissive license.
+It lets anyone use, modify, and redistribute the code, including as part of a larger work under a different license, as long as attribution and the license notice are preserved.
+Beyond the permissions shared by MIT and BSD, Apache 2.0 adds an explicit patent license from contributors to users, together with a patent retaliation clause.
+For scientific software intended to be reused widely, that patent grant provides a layer of protection that the shorter permissive licenses do not.
+
+The deeper reason is reach.
+A permissive license keeps the barriers to adoption as low as possible.
+Researchers and institutions can build on PROTEUS, and integrate parts of it into their own pipelines, without being obliged to release their entire surrounding codebase under a copyleft license.
+This matters in practice: some public research institutes, agencies, and companies restrict or prohibit the use of strong-copyleft code precisely because of that obligation.
+A permissive license keeps the door open to the widest possible set of collaborators.
+
+There are situations where strong copyleft is the right choice, for example when the explicit goal is to ensure that every downstream user must in turn keep their derived code open.
+For the core PROTEUS framework, whose purpose is to enable science and to be reused as broadly as possible, we judge that maximising reach and minimising friction is more important than enforcing that obligation downstream.
+This is why we prefer Apache 2.0, and more permissive licenses generally, for the framework and for the modules we maintain.
+
+## How Apache 2.0 works alongside GPL-3 modules
+
+Some modules used by PROTEUS are released under the GPL-3.0 license.
+Apache 2.0 and GPL-3.0 are compatible in one direction: Apache 2.0 code may be incorporated into a GPL-3.0 project, in which case the combined result is governed by the GPL, but GPL-3.0 code may not be incorporated into an Apache 2.0 project.
+PROTEUS does not incorporate GPL-3.0 source code into its own code base, so this one-directional compatibility is respected.
+
+The framework relies instead on the modular, separately distributed design described above.
+The GPL's strong copyleft obligations attach to the distribution of a combined work.
+Because PROTEUS distributes only its own Apache 2.0 code, and each module is distributed separately by its own authors and obtained directly by the user, PROTEUS itself does not distribute a combined work that includes GPL-3.0 code.
+The modules remain independent programs, each governed by its own license.
+
+We state this plainly so that anyone reusing the framework understands which terms apply.
+When PROTEUS is run together with a GPL-3.0 module, the combined work assembled on your machine is, in the strictest reading, subject to the terms of that module's license.
+Treating each repository's license as authoritative, and keeping the modules optional and swappable, means the framework can always be configured to match the licensing requirements of a given project or institution.
+
+## Permissive licenses are the norm in scientific software
+
+Permissive licensing is the established choice across the scientific software the research community relies on every day.
+The foundational scientific Python stack, including [NumPy](https://numpy.org), [SciPy](https://scipy.org), [pandas](https://pandas.pydata.org), [Matplotlib](https://matplotlib.org), [scikit-learn](https://scikit-learn.org), and [Astropy](https://www.astropy.org), is released under the permissive BSD 3-Clause license.
+Major frameworks such as [TensorFlow](https://www.tensorflow.org) and [JAX](https://github.com/jax-ml/jax) use Apache 2.0, the same license as PROTEUS.
+Many of these tools, including Matplotlib, NumPy, and pandas, grew out of academia and became broadly useful in large part because their permissive licensing posed the fewest obstacles to adoption.
+PROTEUS follows the same path.
+
+## Credit where it is due
+
+A permissive license sets out how code may be used; it says nothing about the credit owed to the people who wrote it.
+We treat scientific credit as a separate and serious obligation, fully independent of licensing.
+PROTEUS exists because of the work of the wider community, and many of its modules build directly on codes developed and published by others.
+
+We are committed to giving that work proper credit:
+
+- The documentation and code link to the relevant publications and repositories for every module, so the original work is easy to find and cite.
+- Modules that wrap or extend an existing code point to the original project and its papers.
+- Users of PROTEUS are asked to cite the manuscripts listed in the [bibliography](https://proteus-framework.org/PROTEUS/Reference/bibliography/), to state the code version used, and to include an acknowledgement.
+
+Our full guidance on citation, authorship, and acknowledgement is set out in the [contributing guidelines](https://proteus-framework.org/PROTEUS/Community/CONTRIBUTING/).
+
+## Questions and discussion
+
+Licensing in open source is a genuinely nuanced area, and reasonable people interpret parts of it differently.
+We have set out our position here in the spirit of transparency, and we welcome questions, corrections, and discussion.
+If you maintain a code we build on, are considering building on PROTEUS, or simply want to understand our approach better, please get in touch.
+
+You can reach us through [GitHub Discussions](https://github.com/orgs/FormingWorlds/discussions), open an issue on the relevant repository, or email [proteus_dev@formingworlds.space](mailto:proteus_dev@formingworlds.space).
+We are always happy to talk this through.
+
+<style>
+  table.lic-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.25rem 0 1.75rem;
+    font-size: 0.95rem;
+  }
+  .lic-table th,
+  .lic-table td {
+    text-align: left;
+    padding: 0.6rem 0.9rem;
+    border-bottom: 1px solid var(--border-color);
+    vertical-align: top;
+  }
+  .lic-table thead th {
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.8rem;
+    color: var(--muted-color);
+    border-bottom: 2px solid var(--border-color);
+  }
+  .lic-table tbody tr:hover { background: var(--card-bg); }
+  .lic-table td:first-child { font-weight: 700; color: var(--heading-color); white-space: nowrap; }
+</style>


### PR DESCRIPTION
**What this does**

Adds a new `/license/` page that explains how PROTEUS and its modules are licensed, and links it from the site navigation.

**Why**

Licensing across the framework spans several licenses (Apache 2.0, MIT, BSD, GPL-3.0), and the non-software assets carry their own (CC BY, CC0). Users, contributors, and institutions need one clear place that states our position: fully open source, permissively licensed at the framework level, with each module under the license its authors chose. This grew out of the discussion in #683.

**Changes**

- New page `_pages/license.md`: open source commitment, the independent-module design, the license table, why PROTEUS uses Apache 2.0, how that works alongside GPL-3 modules, licensing of documentation/data/logos, and our credit guidance.
- `_data/settings.yml`: adds the **License** entry to the main menu.
- `.gitignore`: ignores the local preview overlay and tooling artifacts.

**Testing**

Page content reviewed in #683 and proofed locally. Production builds on Linux, where the root `LICENSE` file and the `/license/` page coexist without the case collision seen on macOS.

Closes #683 once merged.
