### PR TITLE
Centre footer social icons in their round buttons

### DIFF
--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -36,3 +36,22 @@ const buttons = entries.map(([key, url]) => {
     <span class="btn-inner--icon" set:html={b.svg} />
   </button>
 ))}
+
+<style>
+  /* The bundled theme centres these round icon buttons for an icon-font glyph.
+     These buttons carry an inline SVG instead, so centre it with flexbox rather
+     than the glyph-specific offset the theme would otherwise apply. */
+  .btn-icon-only {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    line-height: 1;
+  }
+  .btn-icon-only .btn-inner--icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+  }
+</style>


### PR DESCRIPTION
## What this does

Centres the social-link icons inside their round buttons in the footer. The GitHub mark previously sat low and to the right of the circle; it now sits in the middle.

## Why

The buttons render an inline SVG mark, but the bundled theme only recentres an icon-font glyph, so the SVG was left off-centre (measured at 7px right and 12px down from the button centre).

## Changes

- Add a scoped style to `src/components/Socials.astro` that centres the icon with flexbox and removes the glyph-specific padding and line height.

## Testing

- Rendered the built footer with a browser and measured the icon centre against the button centre: offset went from (7.0, 12.2) px to (0, 0) px, with the button size unchanged at 43px.