### PR TITLE
Redirect mis-cased URLs to the correct page

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -61,6 +61,50 @@ const jsonLd = {
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta charset="utf-8">
 
+  <!-- Send a known path in the wrong letter case to its canonical URL.
+       GitHub Pages matches paths case-sensitively, so a request like /Aragog
+       or /PEOPLE lands on this 404 instead of the real page. This runs before
+       paint and is a no-op when the path is already correctly cased. -->
+  <script is:inline>
+    (function () {
+      var routes = {
+        // Pages served from this repo.
+        modules: '/modules',
+        demos: '/demos',
+        validation: '/validation',
+        testing: '/validation',
+        publications: '/publications',
+        people: '/people',
+        license: '/license',
+        // Module documentation sites (separate repos on this domain).
+        aragog: '/aragog/',
+        calliope: '/CALLIOPE/',
+        janus: '/JANUS/',
+        mors: '/MORS/',
+        obliqua: '/Obliqua/',
+        proteus: '/PROTEUS/',
+        spider: '/SPIDER/',
+        vulcan: '/VULCAN/',
+        zalmoxis: '/Zalmoxis/',
+        zephyrus: '/ZEPHYRUS/',
+      };
+      var m = location.pathname.match(/^\/([^\/]+)(\/.*)?$/);
+      if (!m) return;
+      var key;
+      try {
+        key = decodeURIComponent(m[1]).toLowerCase();
+      } catch (e) {
+        return;
+      }
+      var canonical = routes[key];
+      if (!canonical) return;
+      var canonicalFirst = canonical.replace(/\/$/, '');
+      if ('/' + m[1] === canonicalFirst) return; // already correctly cased
+      var target = m[2] ? canonicalFirst + m[2] : canonical;
+      location.replace(target + location.search + location.hash);
+    })();
+  </script>
+
   <!-- Favicons (light/dark) -->
   <link id="favicon" rel="icon" type="image/png" href={favicons.light}>
 


### PR DESCRIPTION
**What this does**

Sends a URL typed in the wrong letter case to its correct page instead of showing the "Page not found" screen. For example, `proteus-framework.org/Aragog` now lands on the real `/aragog/` docs, and `/PEOPLE` lands on `/people`.

**Why**

GitHub Pages matches paths by exact letter case, so any capitalisation that does not match the real page (a link someone typed, an old bookmark, a copied URL) falls through to our 404 page. That reads as a broken site even though the page exists.

**Changes**

- Add a small script to the shared page head (`src/layouts/Base.astro`) that maps a known path in any letter case to its canonical URL and redirects before the page renders. It covers this site's own pages (Modules, Demos, Validation, Publications, People, License) and the module documentation sites on this domain (aragog, CALLIOPE, JANUS, MORS, Obliqua, PROTEUS, SPIDER, VULCAN, Zalmoxis, ZEPHYRUS), each of which has its own required casing.
- The redirect keeps any deeper path, query string, and fragment, and does nothing when the URL is already correct or points at something genuinely unknown (a real 404).

**Testing**

- Built the site and drove a browser through the redirects: mis-cased own pages resolve to the real page, cross-repo module paths get their casing corrected, deep paths keep their sub-path, and an unknown path still shows the 404. All eleven checks pass.
- Re-ran the theme detection suite to confirm the added head script does not affect first-paint theme selection.

**Note (separate issue, not fixed here)**

The Modules page links AGNI at `proteus-framework.org/AGNI/`, which returns a 404 at every casing because AGNI's docs are hosted at `nichollsh.github.io/AGNI/`, not on this domain. That is a broken link rather than a casing problem, so a casing redirect cannot help it. Happy to fix the link in a follow-up if you want.