### PR TITLE
Point the AGNI docs link at its real location

### DIFF
--- a/src/pages/modules.astro
+++ b/src/pages/modules.astro
@@ -84,7 +84,7 @@ import Base from '../layouts/Base.astro';
       <p class="module-name">AGNI</p>
       <p class="module-desc">Solves the radiative-convective equilibrium of the atmosphere column, computing temperature profiles, fluxes, and the outgoing longwave radiation that controls planetary cooling.</p>
     </div>
-    <div class="module-link"><a href="https://proteus-framework.org/AGNI/" target="_blank" rel="noopener noreferrer">Docs <i class="ni ni-bold-right"></i></a></div>
+    <div class="module-link"><a href="https://nichollsh.github.io/AGNI/" target="_blank" rel="noopener noreferrer">Docs <i class="ni ni-bold-right"></i></a></div>
   </div>
   <div class="module-card">
     <div class="module-accent accent-atmos"></div>


### PR DESCRIPTION
**What this does**

Fixes the AGNI "Docs" link on the Modules page so it opens AGNI's actual documentation instead of a 404.

**Why**

The link pointed at `proteus-framework.org/AGNI/`, which does not exist. AGNI is developed and documented outside this domain, at `nichollsh.github.io/AGNI/`, so the old link always returned "Page not found".

**Changes**

- Repoint the AGNI Docs link in `src/pages/modules.astro` to `https://nichollsh.github.io/AGNI/`, consistent with how the other externally hosted modules (Atmodeller, LovePy) link out to their own pages.

**Testing**

- Confirmed the new target returns HTTP 200.
- Built the site and checked the rendered Modules page contains only the corrected link.