### PR TITLE
Add live AGNI and atmodeller badges to the validation page

### DIFF
--- a/.github/scripts/refresh_coverage_badges.py
+++ b/.github/scripts/refresh_coverage_badges.py
@@ -39,18 +39,17 @@ import yaml
 API_URL = "https://api.codecov.io/api/v2/github/{owner}/repos/{repo}/"
 
 
-def fetch_coverage(owner: str, repo: str, attempts: int = 4, timeout: int = 25) -> float:
-    """Return the default-branch line coverage percent for a Codecov repo.
+def _get_json(url: str, attempts: int = 4, timeout: int = 25) -> dict:
+    """Fetch a JSON object from a Codecov URL with linear backoff.
 
-    Retries a few times with a linear backoff so a slow or briefly unavailable
-    Codecov response does not fail the run on the first miss.
+    Retries a few times so a slow or briefly unavailable Codecov response does
+    not fail the run on the first miss.
 
     Raises
     ------
     RuntimeError
-        If every attempt fails or the response carries no coverage total.
+        If every attempt fails or the body is not a JSON object.
     """
-    url = API_URL.format(owner=owner, repo=repo)
     last_error: Exception | None = None
     for attempt in range(1, attempts + 1):
         try:
@@ -59,17 +58,50 @@ def fetch_coverage(owner: str, repo: str, attempts: int = 4, timeout: int = 25) 
                 payload = json.load(response)
             if not isinstance(payload, dict):
                 raise ValueError("response body was not a JSON object")
-            totals = payload.get("totals")
-            if not isinstance(totals, dict):
-                raise ValueError("response carried no totals object")
-            coverage = totals.get("coverage")
-            if not isinstance(coverage, (int, float, str)):
-                raise ValueError("response carried no usable coverage total")
-            return float(coverage)
+            return payload
         except (urllib.error.URLError, ValueError, json.JSONDecodeError, TimeoutError) as error:
             last_error = error
             time.sleep(2 * attempt)
-    raise RuntimeError(f"Codecov query failed for {owner}/{repo}: {last_error}")
+    raise RuntimeError(f"Codecov request failed for {url}: {last_error}")
+
+
+def _coverage_of(totals: object) -> float | None:
+    """Pull a numeric coverage percent out of a Codecov totals object, or None."""
+    if isinstance(totals, dict):
+        coverage = totals.get("coverage")
+        if isinstance(coverage, (int, float, str)):
+            return float(coverage)
+    return None
+
+
+def fetch_coverage(owner: str, repo: str) -> float:
+    """Return the default-branch line coverage percent for a Codecov repo.
+
+    The repository summary is read first. A repo that was only just activated on
+    Codecov can serve a fully processed commit while its repository-level
+    ``totals`` object is still empty; in that case the default branch's
+    head-commit total, which carries the same figure, is used instead.
+
+    Raises
+    ------
+    RuntimeError
+        If neither the repository summary nor the default branch yields a
+        coverage total.
+    """
+    repo_url = API_URL.format(owner=owner, repo=repo)
+    payload = _get_json(repo_url)
+    coverage = _coverage_of(payload.get("totals"))
+    if coverage is not None:
+        return coverage
+
+    branch = payload.get("default_branch") or "main"
+    branch_payload = _get_json(f"{repo_url}branches/{branch}/")
+    head_commit = branch_payload.get("head_commit")
+    coverage = _coverage_of(head_commit.get("totals") if isinstance(head_commit, dict) else None)
+    if coverage is not None:
+        return coverage
+
+    raise RuntimeError(f"no coverage total for {owner}/{repo} (repository or {branch} head)")
 
 
 def color_for(percent: float) -> str:

--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -142,7 +142,7 @@ in_development:
     owner: FormingWorlds
     repo: Obliqua
     workflow: runtests.yml
-    ci_label: tests
+    ci_label: CI
     total: "custom suite"
     breakdown: "Hand-written Julia validation runner, Test.jl migration planned"
 

--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -68,7 +68,7 @@ mature:
     owner: nichollsh
     repo: AGNI
     workflow: install_and_test.yml
-    ci_label: tests
+    ci_label: CI
     has_codecov: true
     total_endpoint: https://gist.githubusercontent.com/nichollsh/e20f4fa3c7811c75d34005311fef3696/raw/tests-total.json
     markers:

--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -76,13 +76,15 @@ mature:
       integration: https://gist.githubusercontent.com/nichollsh/e20f4fa3c7811c75d34005311fef3696/raw/tests-integration.json
 
   - name: atmodeller
-    owner: ExPlanetology
+    owner: FormingWorlds
     repo: atmodeller
     workflow: ci.yml
     ci_label: CI
-    has_codecov: false
-    total: 138
-    breakdown: "PROTEUS-style markers being adopted"
+    has_codecov: true
+    total_endpoint: https://gist.githubusercontent.com/timlichtenberg/3b0d1370019572c00e2650799e81717d/raw/tests-total.json
+    markers:
+      unit: https://gist.githubusercontent.com/timlichtenberg/3b0d1370019572c00e2650799e81717d/raw/tests-unit.json
+      integration: https://gist.githubusercontent.com/timlichtenberg/3b0d1370019572c00e2650799e81717d/raw/tests-integration.json
 
   - name: CALLIOPE
     owner: FormingWorlds

--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -21,8 +21,10 @@
 #   total_endpoint Optional. Path of the shields.io-compatible JSON file,
 #                    relative to `badge_branch` (e.g. "tests-total.json" at the
 #                    root of a badges branch, or ".github/badges/tests-total.json"
-#                    on main). When set, the row renders a live shields.io
-#                    endpoint badge instead of the static `total`.
+#                    on main), or a full https URL to the JSON (e.g. a gist raw
+#                    endpoint that the module's CI publishes). When set, the row
+#                    renders a live shields.io endpoint badge instead of the
+#                    static `total`.
 #   badge_branch   Optional. Branch that holds the badge JSON files. Defaults
 #                    to "main". Repos with a protected main publish the JSON to
 #                    a dedicated "badges" branch instead; set this to that
@@ -33,9 +35,9 @@
 #   breakdown      Optional. Plain-text marker breakdown ("816 unit, ...").
 #                    Used until per-marker endpoint files are published.
 #   markers        Optional. Map of marker name to JSON path (relative to
-#                    `badge_branch`); when set, each marker renders as a live
-#                    shields.io badge in place of `breakdown`. Keys: unit,
-#                    integration, smoke, slow.
+#                    `badge_branch`) or full https URL; when set, each marker
+#                    renders as a live shields.io badge in place of `breakdown`.
+#                    Keys: unit, integration, smoke, slow.
 
 mature:
   - name: PROTEUS
@@ -68,8 +70,10 @@ mature:
     workflow: install_and_test.yml
     ci_label: tests
     has_codecov: true
-    total: 707
-    breakdown: "707 <code>@test</code> assertions in 150 testsets (Julia <code>Test.jl</code>)"
+    total_endpoint: https://gist.githubusercontent.com/nichollsh/e20f4fa3c7811c75d34005311fef3696/raw/tests-total.json
+    markers:
+      unit: https://gist.githubusercontent.com/nichollsh/e20f4fa3c7811c75d34005311fef3696/raw/tests-unit.json
+      integration: https://gist.githubusercontent.com/nichollsh/e20f4fa3c7811c75d34005311fef3696/raw/tests-integration.json
 
   - name: atmodeller
     owner: ExPlanetology

--- a/scripts/generate-badges.mjs
+++ b/scripts/generate-badges.mjs
@@ -46,11 +46,12 @@ function logoDataUri(icon) {
 const LOGO_GITHUB = logoDataUri(simpleIcons.siGithub);
 const LOGO_CODECOV = logoDataUri(simpleIcons.siCodecov);
 
-// House color for test-count and marker badges. Their color carries no
-// pass/fail meaning, so every module renders in the same blue for a uniform
-// row, regardless of the color its endpoint happens to emit. Only the count
-// itself comes from the endpoint.
+// House style for test-count and marker badges. Their color carries no
+// pass/fail meaning, so every module renders in the same blue with a
+// lower-cased label for a uniform row, regardless of what its endpoint emits.
+// Only the count itself comes from the endpoint.
 const COUNT_COLOR = 'blue';
+const houseCount = (d) => ({ ...d, label: (d.label ?? '').toLowerCase(), color: COUNT_COLOR });
 
 /** Lower-cased repo name used as the file-name slug for a module. */
 const slugOf = (mod) => mod.repo.toLowerCase();
@@ -168,14 +169,14 @@ async function main() {
     if (mod.total_endpoint) {
       const url = endpointUrl(mod, mod.total_endpoint, branch);
       jobs.push(
-        fetchEndpoint(url).then((d) => writeBadge(`tests-total-${slug}`, d && render({ ...d, color: COUNT_COLOR }), 'tests')),
+        fetchEndpoint(url).then((d) => writeBadge(`tests-total-${slug}`, d && render(houseCount(d)), 'tests')),
       );
     }
 
     for (const [marker, file] of Object.entries(mod.markers ?? {})) {
       const url = endpointUrl(mod, file, branch);
       jobs.push(
-        fetchEndpoint(url).then((d) => writeBadge(`tests-${marker}-${slug}`, d && render({ ...d, color: COUNT_COLOR }), marker)),
+        fetchEndpoint(url).then((d) => writeBadge(`tests-${marker}-${slug}`, d && render(houseCount(d)), marker)),
       );
     }
 

--- a/scripts/generate-badges.mjs
+++ b/scripts/generate-badges.mjs
@@ -46,8 +46,25 @@ function logoDataUri(icon) {
 const LOGO_GITHUB = logoDataUri(simpleIcons.siGithub);
 const LOGO_CODECOV = logoDataUri(simpleIcons.siCodecov);
 
+// House color for test-count and marker badges. Their color carries no
+// pass/fail meaning, so every module renders in the same blue for a uniform
+// row, regardless of the color its endpoint happens to emit. Only the count
+// itself comes from the endpoint.
+const COUNT_COLOR = 'blue';
+
 /** Lower-cased repo name used as the file-name slug for a module. */
 const slugOf = (mod) => mod.repo.toLowerCase();
+
+/**
+ * Resolve a test-count endpoint to a raw URL. A value that is already an
+ * absolute URL (for example a gist raw endpoint that a module's CI publishes)
+ * is used verbatim; a bare file name is resolved against the module's repo and
+ * badge branch.
+ */
+function endpointUrl(mod, file, branch) {
+  if (/^https?:\/\//i.test(file)) return file;
+  return `${RAW}/${mod.owner}/${mod.repo}/${branch}/${file}`;
+}
 
 /** Fetch a URL with a timeout and a few retries; returns the Response or null. */
 async function fetchWithRetry(url, headers = {}) {
@@ -149,16 +166,16 @@ async function main() {
     }
 
     if (mod.total_endpoint) {
-      const url = `${RAW}/${mod.owner}/${mod.repo}/${branch}/${mod.total_endpoint}`;
+      const url = endpointUrl(mod, mod.total_endpoint, branch);
       jobs.push(
-        fetchEndpoint(url).then((d) => writeBadge(`tests-total-${slug}`, d && render(d), 'tests')),
+        fetchEndpoint(url).then((d) => writeBadge(`tests-total-${slug}`, d && render({ ...d, color: COUNT_COLOR }), 'tests')),
       );
     }
 
     for (const [marker, file] of Object.entries(mod.markers ?? {})) {
-      const url = `${RAW}/${mod.owner}/${mod.repo}/${branch}/${file}`;
+      const url = endpointUrl(mod, file, branch);
       jobs.push(
-        fetchEndpoint(url).then((d) => writeBadge(`tests-${marker}-${slug}`, d && render(d), marker)),
+        fetchEndpoint(url).then((d) => writeBadge(`tests-${marker}-${slug}`, d && render({ ...d, color: COUNT_COLOR }), marker)),
       );
     }
 

--- a/scripts/generate-badges.mjs
+++ b/scripts/generate-badges.mjs
@@ -47,11 +47,13 @@ const LOGO_GITHUB = logoDataUri(simpleIcons.siGithub);
 const LOGO_CODECOV = logoDataUri(simpleIcons.siCodecov);
 
 // House style for test-count and marker badges. Their color carries no
-// pass/fail meaning, so every module renders in the same blue with a
-// lower-cased label for a uniform row, regardless of what its endpoint emits.
-// Only the count itself comes from the endpoint.
+// pass/fail meaning, so every module renders in the same blue. The label is
+// fixed by the badge's role (the total badge reads "tests", a marker badge
+// reads its marker name), not taken from the endpoint, so the row reads
+// identically no matter what wording a module's own endpoint emits. Only the
+// count itself comes from the endpoint.
 const COUNT_COLOR = 'blue';
-const houseCount = (d) => ({ ...d, label: (d.label ?? '').toLowerCase(), color: COUNT_COLOR });
+const houseCount = (d, label) => ({ label, message: d.message, color: COUNT_COLOR });
 
 /** Lower-cased repo name used as the file-name slug for a module. */
 const slugOf = (mod) => mod.repo.toLowerCase();
@@ -169,14 +171,14 @@ async function main() {
     if (mod.total_endpoint) {
       const url = endpointUrl(mod, mod.total_endpoint, branch);
       jobs.push(
-        fetchEndpoint(url).then((d) => writeBadge(`tests-total-${slug}`, d && render(houseCount(d)), 'tests')),
+        fetchEndpoint(url).then((d) => writeBadge(`tests-total-${slug}`, d && render(houseCount(d, 'tests')), 'tests')),
       );
     }
 
     for (const [marker, file] of Object.entries(mod.markers ?? {})) {
       const url = endpointUrl(mod, file, branch);
       jobs.push(
-        fetchEndpoint(url).then((d) => writeBadge(`tests-${marker}-${slug}`, d && render(houseCount(d)), marker)),
+        fetchEndpoint(url).then((d) => writeBadge(`tests-${marker}-${slug}`, d && render(houseCount(d, marker)), marker)),
       );
     }
 

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -65,6 +65,8 @@ import Base from '../layouts/Base.astro';
     font-size: 0.85rem;
     line-height: 1.35;
   }
+  /* Space the marker badges (unit, integration) apart from each other. */
+  .coverage-table td.test-breakdown a + a { margin-left: 0.4rem; }
 
   .test-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin: 1rem 0 1.5rem; }
   .test-card {

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -339,7 +339,7 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td class="module-name"><a href="https://github.com/nichollsh/AGNI">AGNI</a></td>
       <td class="test-count"><a href="https://gist.github.com/nichollsh/e20f4fa3c7811c75d34005311fef3696#file-tests-total-json"><img src="/assets/badges/tests-total-agni.svg" alt="tests" /></a></td>
       <td class="test-breakdown"><a href="https://gist.github.com/nichollsh/e20f4fa3c7811c75d34005311fef3696#file-tests-unit-json"><img src="/assets/badges/tests-unit-agni.svg" alt="unit" /></a><a href="https://gist.github.com/nichollsh/e20f4fa3c7811c75d34005311fef3696#file-tests-integration-json"><img src="/assets/badges/tests-integration-agni.svg" alt="integration" /></a></td>
-      <td><a href="https://github.com/nichollsh/AGNI/actions/workflows/install_and_test.yml"><img src="/assets/badges/ci-agni.svg" alt="tests" /></a></td>
+      <td><a href="https://github.com/nichollsh/AGNI/actions/workflows/install_and_test.yml"><img src="/assets/badges/ci-agni.svg" alt="CI" /></a></td>
       <td><a href="https://app.codecov.io/gh/nichollsh/AGNI"><img src="/assets/badges/coverage-agni.svg" alt="coverage" /></a></td>
     </tr>
     <tr>

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -335,8 +335,8 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
     </tr>
     <tr>
       <td class="module-name"><a href="https://github.com/nichollsh/AGNI">AGNI</a></td>
-      <td class="test-count">707</td>
-      <td class="test-breakdown">707 <code>@test</code> assertions in 150 testsets (Julia <code>Test.jl</code>)</td>
+      <td class="test-count"><a href="https://gist.github.com/nichollsh/e20f4fa3c7811c75d34005311fef3696#file-tests-total-json"><img src="/assets/badges/tests-total-agni.svg" alt="tests" /></a></td>
+      <td class="test-breakdown"><a href="https://gist.github.com/nichollsh/e20f4fa3c7811c75d34005311fef3696#file-tests-unit-json"><img src="/assets/badges/tests-unit-agni.svg" alt="unit" /></a><a href="https://gist.github.com/nichollsh/e20f4fa3c7811c75d34005311fef3696#file-tests-integration-json"><img src="/assets/badges/tests-integration-agni.svg" alt="integration" /></a></td>
       <td><a href="https://github.com/nichollsh/AGNI/actions/workflows/install_and_test.yml"><img src="/assets/badges/ci-agni.svg" alt="tests" /></a></td>
       <td><a href="https://app.codecov.io/gh/nichollsh/AGNI"><img src="/assets/badges/coverage-agni.svg" alt="coverage" /></a></td>
     </tr>

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -401,7 +401,7 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td class="module-name"><a href="https://github.com/FormingWorlds/Obliqua">Obliqua</a></td>
       <td class="test-count">custom suite</td>
       <td class="test-breakdown">Hand-written Julia validation runner, Test.jl migration planned</td>
-      <td><a href="https://github.com/FormingWorlds/Obliqua/actions/workflows/runtests.yml"><img src="/assets/badges/ci-obliqua.svg" alt="tests" /></a></td>
+      <td><a href="https://github.com/FormingWorlds/Obliqua/actions/workflows/runtests.yml"><img src="/assets/badges/ci-obliqua.svg" alt="CI" /></a></td>
     </tr>
     <tr>
       <td class="module-name"><a href="https://github.com/FormingWorlds/SPIDER">SPIDER</a></td>

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -343,11 +343,11 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td><a href="https://app.codecov.io/gh/nichollsh/AGNI"><img src="/assets/badges/coverage-agni.svg" alt="coverage" /></a></td>
     </tr>
     <tr>
-      <td class="module-name"><a href="https://github.com/ExPlanetology/atmodeller">atmodeller</a></td>
-      <td class="test-count">138</td>
-      <td class="test-breakdown">PROTEUS-style markers being adopted</td>
-      <td><a href="https://github.com/ExPlanetology/atmodeller/actions/workflows/ci.yml"><img src="/assets/badges/ci-atmodeller.svg" alt="CI" /></a></td>
-      <td><span style="color: var(--muted-color); font-size: 0.85rem;">Codecov pending</span></td>
+      <td class="module-name"><a href="https://github.com/FormingWorlds/atmodeller">atmodeller</a></td>
+      <td class="test-count"><a href="https://gist.github.com/timlichtenberg/3b0d1370019572c00e2650799e81717d#file-tests-total-json"><img src="/assets/badges/tests-total-atmodeller.svg" alt="tests" /></a></td>
+      <td class="test-breakdown"><a href="https://gist.github.com/timlichtenberg/3b0d1370019572c00e2650799e81717d#file-tests-unit-json"><img src="/assets/badges/tests-unit-atmodeller.svg" alt="unit" /></a><a href="https://gist.github.com/timlichtenberg/3b0d1370019572c00e2650799e81717d#file-tests-integration-json"><img src="/assets/badges/tests-integration-atmodeller.svg" alt="integration" /></a></td>
+      <td><a href="https://github.com/FormingWorlds/atmodeller/actions/workflows/ci.yml"><img src="/assets/badges/ci-atmodeller.svg" alt="CI" /></a></td>
+      <td><a href="https://app.codecov.io/gh/FormingWorlds/atmodeller"><img src="/assets/badges/coverage-atmodeller.svg" alt="coverage" /></a></td>
     </tr>
     <tr>
       <td class="module-name"><a href="https://github.com/FormingWorlds/CALLIOPE">CALLIOPE</a></td>

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -68,6 +68,17 @@ import Base from '../layouts/Base.astro';
   /* Space the marker badges (unit, integration) apart from each other. */
   .coverage-table td.test-breakdown a + a { margin-left: 0.4rem; }
 
+  /* Both module tables share one fixed column geometry, so the "Mature suites"
+     and "Suites in development" tables line up column-for-column and read as a
+     single grid. In-development modules carry no coverage figure, so their
+     fifth column is reserved but empty. */
+  .coverage-table { table-layout: fixed; }
+  .coverage-table col.col-module { width: 20%; }
+  .coverage-table col.col-count { width: 17%; }
+  .coverage-table col.col-breakdown { width: 30%; }
+  .coverage-table col.col-ci { width: 17%; }
+  .coverage-table col.col-coverage { width: 16%; }
+
   .test-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin: 1rem 0 1.5rem; }
   .test-card {
     border: 1px solid var(--border-color);
@@ -306,11 +317,18 @@ The full developer-facing detail is on the PROTEUS <a href="https://proteus-fram
 
 <h4>Code coverage and test counts</h4>
 
-The PROTEUS framework and its mature submodules expose passing-tests badges and, where wired, line-coverage badges from <a href="https://app.codecov.io/gh/FormingWorlds" target="_blank" rel="noopener noreferrer">Codecov</a>. Test counts marked with a live badge refresh automatically from each repository's CI; static counts are snapshots from the date in the footnote below. Each row links to the public repository behind it, and every live badge to the workflow or coverage report that generated it, so the figures can be checked at source.
+The PROTEUS framework and its mature submodules expose passing-tests badges and, where wired, line-coverage badges from <a href="https://app.codecov.io/gh/FormingWorlds" target="_blank" rel="noopener noreferrer">Codecov</a>. Test counts marked with a live badge refresh automatically from each repository's CI. Each row links to the public repository behind it, and every live badge to the workflow or coverage report that generated it, so the figures can be checked at source.
 
 <p style="font-size: 0.95rem; margin-bottom: 0.4rem;"><strong>Mature suites</strong></p>
 
 <table class="coverage-table">
+  <colgroup>
+    <col class="col-module" />
+    <col class="col-count" />
+    <col class="col-breakdown" />
+    <col class="col-ci" />
+    <col class="col-coverage" />
+  </colgroup>
   <thead>
     <tr>
       <th>Module</th>
@@ -370,6 +388,13 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
 <p style="font-size: 0.95rem; margin: 1.4rem 0 0.4rem;"><strong>Suites in development</strong></p>
 
 <table class="coverage-table">
+  <colgroup>
+    <col class="col-module" />
+    <col class="col-count" />
+    <col class="col-breakdown" />
+    <col class="col-ci" />
+    <col class="col-coverage" />
+  </colgroup>
   <thead>
     <tr>
       <th>Module</th>
@@ -425,7 +450,7 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
   </tbody>
 </table>
 
-<p class="footnote">Rows displaying a numeric badge are live. The count is fetched from each repository's automated workflows, and republished whenever the repository's tests change. The remaining plain number rows are static counts ( last verified on 4 July 2026). Ecosystem-wide adoption of the PROTEUS marker convention (unit, smoke, integration, slow) is a point of active development.</p>
+<p class="footnote">Rows displaying a numeric badge are live. The count is fetched from each repository's automated workflows, and republished whenever the repository's tests change. Ecosystem-wide adoption of the PROTEUS marker convention (unit, smoke, integration, slow) is a point of active development.</p>
 
 <h4 id="tests-and-papers">Tests and papers</h4>
 


### PR DESCRIPTION
## What this does

Adds live, self-hosted status badges for AGNI and atmodeller to the validation page, including atmodeller's Codecov line-coverage badge, and gives the two module tables one shared column layout so they read as a single grid.

## Why

The validation page listed AGNI and atmodeller without live figures, and atmodeller had no coverage badge at all. I want every mature module to show the same set of live badges, refreshed automatically from each repository, and the two tables to line up visually.

## Changes

- Show AGNI and atmodeller test counts (total, unit, integration) as live badges fed from each repository's published counts.
- Render atmodeller's coverage badge from Codecov, alongside the other modules.
- Fix each test-count label by its role, so every module reads with the same short "unit" and "integration" labels regardless of what its own endpoint publishes.
- Give both module tables one fixed column layout, so the mature and in-development tables align column-for-column.
- Keep the coverage refresh working for a freshly activated Codecov repository by falling back to the default branch's head-commit total when the repository summary is still empty.
- Trim the outdated static-count footnote now that every count row renders a live badge.

## Testing

- Ran the badge generator and a production build; all 43 badges resolve with no placeholders.
- Confirmed atmodeller coverage reads 93% end to end: the refresh workflow published `coverage-atmodeller.json` to the `badges` branch, and a local rebuild rendered the coverage badge from it.
- Inspected the rendered page on a local server: short labels on every module and both tables aligned.
