### PR TITLE
Move MORS into the mature test suites on the validation page

### DIFF
--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -110,16 +110,19 @@ mature:
       unit: tests-unit.json
       integration: tests-integration.json
 
-in_development:
   - name: MORS
     owner: FormingWorlds
     repo: MORS
     workflow: tests.yaml
     ci_label: CI
+    has_codecov: true
     total_endpoint: tests-total.json
     badge_branch: badges
-    breakdown: "Total count; tests parametrized, not tier-marked"
+    markers:
+      unit: tests-unit.json
+      integration: tests-integration.json
 
+in_development:
   - name: JANUS
     owner: FormingWorlds
     repo: JANUS

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -381,6 +381,13 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td><a href="https://github.com/FormingWorlds/aragog/actions/workflows/ci_tests.yml"><img src="/assets/badges/ci-aragog.svg" alt="CI" /></a></td>
       <td><a href="https://app.codecov.io/gh/FormingWorlds/aragog"><img src="/assets/badges/coverage-aragog.svg" alt="coverage" /></a></td>
     </tr>
+    <tr>
+      <td class="module-name"><a href="https://github.com/FormingWorlds/MORS">MORS</a></td>
+      <td class="test-count"><a href="https://github.com/FormingWorlds/MORS/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-mors.svg" alt="tests" /></a></td>
+      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/MORS/blob/badges/tests-unit.json"><img src="/assets/badges/tests-unit-mors.svg" alt="unit" /></a><a href="https://github.com/FormingWorlds/MORS/blob/badges/tests-integration.json"><img src="/assets/badges/tests-integration-mors.svg" alt="integration" /></a></td>
+      <td><a href="https://github.com/FormingWorlds/MORS/actions/workflows/tests.yaml"><img src="/assets/badges/ci-mors.svg" alt="CI" /></a></td>
+      <td><a href="https://app.codecov.io/gh/FormingWorlds/MORS"><img src="/assets/badges/coverage-mors.svg" alt="coverage" /></a></td>
+    </tr>
 
   </tbody>
 </table>
@@ -404,12 +411,6 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td class="module-name"><a href="https://github.com/FormingWorlds/MORS">MORS</a></td>
-      <td class="test-count"><a href="https://github.com/FormingWorlds/MORS/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-mors.svg" alt="tests" /></a></td>
-      <td class="test-breakdown">Total count; tests parametrized, not tier-marked</td>
-      <td><a href="https://github.com/FormingWorlds/MORS/actions/workflows/tests.yaml"><img src="/assets/badges/ci-mors.svg" alt="CI" /></a></td>
-    </tr>
     <tr>
       <td class="module-name"><a href="https://github.com/FormingWorlds/JANUS">JANUS</a></td>
       <td class="test-count"><a href="https://github.com/FormingWorlds/JANUS/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-janus.svg" alt="tests" /></a></td>


### PR DESCRIPTION
**What this does**

Promotes MORS from the "Suites in development" table to the "Mature suites" table on the validation page, so it sits alongside PROTEUS, CALLIOPE, Aragog, and the other established modules with a full test breakdown and a coverage column.

**Why**

MORS now has tier-marked tests (unit, integration) and publishes per-marker count badges to its badges branch, which is the bar for the mature table. It no longer belongs in the in-development list.

**Changes**

- `src/pages/validation.astro`: move the MORS row into the Mature suites table with the unit plus integration breakdown and a coverage column, and drop it from the in-development table.
- `data/test_counts.yml`: move the MORS entry into the mature group, add its unit and integration marker endpoints, and turn on the coverage badge.

**Testing**

Ran `npm run build` and served the result. MORS renders in the mature table with tests 271, unit 203, integration 68, and CI passing; the other tables are unchanged. The coverage badge shows a neutral placeholder until MORS is connected to Codecov, at which point it populates on the next daily refresh.