### PR TITLE
Move ZEPHYRUS into the mature test suites on the validation page

### DIFF
--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -122,6 +122,18 @@ mature:
       unit: tests-unit.json
       integration: tests-integration.json
 
+  - name: ZEPHYRUS
+    owner: FormingWorlds
+    repo: ZEPHYRUS
+    workflow: tests.yaml
+    ci_label: CI
+    has_codecov: true
+    total_endpoint: tests-total.json
+    badge_branch: badges
+    markers:
+      unit: tests-unit.json
+      integration: tests-integration.json
+
 in_development:
   - name: JANUS
     owner: FormingWorlds
@@ -159,15 +171,6 @@ in_development:
     total_endpoint: tests-total.json
     badge_branch: badges
     breakdown: "SciATH integration cases for the C/PETSc solver"
-
-  - name: ZEPHYRUS
-    owner: FormingWorlds
-    repo: ZEPHYRUS
-    workflow: tests.yaml
-    ci_label: CI
-    total_endpoint: tests-total.json
-    badge_branch: badges
-    breakdown: "Test scaffold in place; suite under construction"
 
   - name: LovePy
     owner: nichollsh

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -388,6 +388,13 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td><a href="https://github.com/FormingWorlds/MORS/actions/workflows/tests.yaml"><img src="/assets/badges/ci-mors.svg" alt="CI" /></a></td>
       <td><a href="https://app.codecov.io/gh/FormingWorlds/MORS"><img src="/assets/badges/coverage-mors.svg" alt="coverage" /></a></td>
     </tr>
+    <tr>
+      <td class="module-name"><a href="https://github.com/FormingWorlds/ZEPHYRUS">ZEPHYRUS</a></td>
+      <td class="test-count"><a href="https://github.com/FormingWorlds/ZEPHYRUS/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-zephyrus.svg" alt="tests" /></a></td>
+      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/ZEPHYRUS/blob/badges/tests-unit.json"><img src="/assets/badges/tests-unit-zephyrus.svg" alt="unit" /></a><a href="https://github.com/FormingWorlds/ZEPHYRUS/blob/badges/tests-integration.json"><img src="/assets/badges/tests-integration-zephyrus.svg" alt="integration" /></a></td>
+      <td><a href="https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/tests.yaml"><img src="/assets/badges/ci-zephyrus.svg" alt="CI" /></a></td>
+      <td><a href="https://app.codecov.io/gh/FormingWorlds/ZEPHYRUS"><img src="/assets/badges/coverage-zephyrus.svg" alt="coverage" /></a></td>
+    </tr>
 
   </tbody>
 </table>
@@ -434,12 +441,6 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td class="test-count"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-spider.svg" alt="tests" /></a></td>
       <td class="test-breakdown">SciATH integration cases for the C/PETSc solver</td>
       <td><a href="https://github.com/FormingWorlds/SPIDER/actions/workflows/ci.yml"><img src="/assets/badges/ci-spider.svg" alt="CI" /></a></td>
-    </tr>
-    <tr>
-      <td class="module-name"><a href="https://github.com/FormingWorlds/ZEPHYRUS">ZEPHYRUS</a></td>
-      <td class="test-count"><a href="https://github.com/FormingWorlds/ZEPHYRUS/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-zephyrus.svg" alt="tests" /></a></td>
-      <td class="test-breakdown">Test scaffold in place; suite under construction</td>
-      <td><a href="https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/tests.yaml"><img src="/assets/badges/ci-zephyrus.svg" alt="CI" /></a></td>
     </tr>
     <tr>
       <td class="module-name"><a href="https://github.com/nichollsh/lovepy">LovePy</a></td>


### PR DESCRIPTION
## What this does

Promotes ZEPHYRUS from "Suites in development" to "Mature suites" on the validation page, matching the format of the other mature modules (test total, unit and integration breakdown, CI status, coverage).

## Why

ZEPHYRUS now publishes tier-marked unit and integration test counts on its `badges` branch, so it belongs alongside the other mature suites rather than in the in-development list.

## Changes

- `src/pages/validation.astro`: move the ZEPHYRUS row into the mature-suites table with the full five-column layout, and drop it from the in-development table.
- `data/test_counts.yml`: move the ZEPHYRUS entry to `mature` with `has_codecov: true` and unit/integration markers.

## Testing

Local production build renders the row cleanly: tests 29, unit 26, integration 3, CI passing. The coverage badge shows a placeholder until ZEPHYRUS uploads its first coverage report to Codecov, after which the daily coverage refresh fills it in automatically.