### PR TITLE
Move SPIDER into the mature test suites on the validation page

### DIFF
--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -134,6 +134,18 @@ mature:
       unit: tests-unit.json
       integration: tests-integration.json
 
+  - name: SPIDER
+    owner: FormingWorlds
+    repo: SPIDER
+    workflow: ci.yml
+    ci_label: CI
+    has_codecov: true
+    total_endpoint: tests-total.json
+    badge_branch: badges
+    markers:
+      fast: tests-fast.json
+      nightly: tests-nightly.json
+
 in_development:
   - name: JANUS
     owner: FormingWorlds
@@ -162,15 +174,6 @@ in_development:
     ci_label: CI
     total: "custom suite"
     breakdown: "Hand-written Julia validation runner, Test.jl migration planned"
-
-  - name: SPIDER
-    owner: FormingWorlds
-    repo: SPIDER
-    workflow: ci.yml
-    ci_label: CI
-    total_endpoint: tests-total.json
-    badge_branch: badges
-    breakdown: "SciATH integration cases for the C/PETSc solver"
 
   - name: LovePy
     owner: nichollsh

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -395,6 +395,13 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td><a href="https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/tests.yaml"><img src="/assets/badges/ci-zephyrus.svg" alt="CI" /></a></td>
       <td><a href="https://app.codecov.io/gh/FormingWorlds/ZEPHYRUS"><img src="/assets/badges/coverage-zephyrus.svg" alt="coverage" /></a></td>
     </tr>
+    <tr>
+      <td class="module-name"><a href="https://github.com/FormingWorlds/SPIDER">SPIDER</a></td>
+      <td class="test-count"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-spider.svg" alt="tests" /></a></td>
+      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-fast.json"><img src="/assets/badges/tests-fast-spider.svg" alt="fast" /></a><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-nightly.json"><img src="/assets/badges/tests-nightly-spider.svg" alt="nightly" /></a></td>
+      <td><a href="https://github.com/FormingWorlds/SPIDER/actions/workflows/ci.yml"><img src="/assets/badges/ci-spider.svg" alt="CI" /></a></td>
+      <td><a href="https://app.codecov.io/gh/FormingWorlds/SPIDER"><img src="/assets/badges/coverage-spider.svg" alt="coverage" /></a></td>
+    </tr>
 
   </tbody>
 </table>
@@ -435,12 +442,6 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td class="test-count">custom suite</td>
       <td class="test-breakdown">Hand-written Julia validation runner, Test.jl migration planned</td>
       <td><a href="https://github.com/FormingWorlds/Obliqua/actions/workflows/runtests.yml"><img src="/assets/badges/ci-obliqua.svg" alt="CI" /></a></td>
-    </tr>
-    <tr>
-      <td class="module-name"><a href="https://github.com/FormingWorlds/SPIDER">SPIDER</a></td>
-      <td class="test-count"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-spider.svg" alt="tests" /></a></td>
-      <td class="test-breakdown">SciATH integration cases for the C/PETSc solver</td>
-      <td><a href="https://github.com/FormingWorlds/SPIDER/actions/workflows/ci.yml"><img src="/assets/badges/ci-spider.svg" alt="CI" /></a></td>
     </tr>
     <tr>
       <td class="module-name"><a href="https://github.com/nichollsh/lovepy">LovePy</a></td>


### PR DESCRIPTION
**What this does**

Moves SPIDER from the "Suites in development" list into the "Mature suites" table on the validation page, so it sits alongside PROTEUS, Zalmoxis, AGNI, atmodeller, CALLIOPE, Aragog, MORS, and ZEPHYRUS.

**Why**

SPIDER now runs the ecosystem's tiered test framework: a capped fast tier on every pull request and a full nightly tier, with line coverage uploaded to Codecov. It publishes fast and nightly count badges to its badges branch, which is the bar the mature suites meet.

**Changes**

- `src/pages/validation.astro`: remove the SPIDER row from the in-development table and add a five-column row to the mature table (tests-total, fast/nightly breakdown, CI, coverage).
- `data/test_counts.yml`: move the SPIDER entry into the mature group, set `has_codecov: true`, and switch the breakdown markers from unit/integration to fast/nightly, matching the C-code test split.

SPIDER is a C code, so its breakdown badges are fast and nightly rather than the Python unit and integration split. The CI badge tracks `ci.yml` (the fast PR tier).

**Testing**

Ran the build-time badge generator and a full `npm run build`. The SPIDER badges render with live values (tests 47, fast 44, nightly 3, CI passing). The coverage badge shows a neutral placeholder until the coverage endpoint is published; the daily coverage refresh, triggered by this change to `test_counts.yml`, will fill in the live figure from Codecov. Confirmed in the built HTML that SPIDER appears once in the mature table with all five badges and no longer appears in the in-development table.