### PR TITLE
Label SPIDER breakdown badges as unit and integration

### DIFF
--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -143,8 +143,8 @@ mature:
     total_endpoint: tests-total.json
     badge_branch: badges
     markers:
-      fast: tests-fast.json
-      nightly: tests-nightly.json
+      unit: tests-fast.json
+      integration: tests-nightly.json
 
 in_development:
   - name: JANUS

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -398,7 +398,7 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
     <tr>
       <td class="module-name"><a href="https://github.com/FormingWorlds/SPIDER">SPIDER</a></td>
       <td class="test-count"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-spider.svg" alt="tests" /></a></td>
-      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-fast.json"><img src="/assets/badges/tests-fast-spider.svg" alt="fast" /></a><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-nightly.json"><img src="/assets/badges/tests-nightly-spider.svg" alt="nightly" /></a></td>
+      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-fast.json"><img src="/assets/badges/tests-unit-spider.svg" alt="unit" /></a><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-nightly.json"><img src="/assets/badges/tests-integration-spider.svg" alt="integration" /></a></td>
       <td><a href="https://github.com/FormingWorlds/SPIDER/actions/workflows/ci.yml"><img src="/assets/badges/ci-spider.svg" alt="CI" /></a></td>
       <td><a href="https://app.codecov.io/gh/FormingWorlds/SPIDER"><img src="/assets/badges/coverage-spider.svg" alt="coverage" /></a></td>
     </tr>


### PR DESCRIPTION
**What this does**

Relabels the SPIDER breakdown badges on the validation page to read "unit" and "integration", so the SPIDER row matches every other mature row instead of showing the fast/nightly tier names.

**Why**

The rest of the mature table uses the unit/integration vocabulary, and SPIDER read fast/nightly, which looked half-migrated next to the other rows.

**Changes**

- `data/test_counts.yml`: rename the SPIDER marker keys from fast/nightly to unit/integration. The counts still come from SPIDER's tests-fast and tests-nightly endpoints until those tiers are renamed at the source.
- `src/pages/validation.astro`: point the breakdown images at the unit/integration SVG names with matching alt text.

**Testing**

Ran the badge generator and a full build. The two badges render "unit 44" and "integration 3"; the built HTML references the unit/integration SVGs and no longer the fast/nightly ones.