### PR TITLE
Read SPIDER breakdown badges from its per-tier test counts

### DIFF
--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -143,8 +143,8 @@ mature:
     total_endpoint: tests-total.json
     badge_branch: badges
     markers:
-      unit: tests-fast.json
-      integration: tests-nightly.json
+      unit: tests-unit.json
+      integration: tests-integration.json
 
 in_development:
   - name: JANUS

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -398,7 +398,7 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
     <tr>
       <td class="module-name"><a href="https://github.com/FormingWorlds/SPIDER">SPIDER</a></td>
       <td class="test-count"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-spider.svg" alt="tests" /></a></td>
-      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-fast.json"><img src="/assets/badges/tests-unit-spider.svg" alt="unit" /></a><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-nightly.json"><img src="/assets/badges/tests-integration-spider.svg" alt="integration" /></a></td>
+      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-unit.json"><img src="/assets/badges/tests-unit-spider.svg" alt="unit" /></a><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-integration.json"><img src="/assets/badges/tests-integration-spider.svg" alt="integration" /></a></td>
       <td><a href="https://github.com/FormingWorlds/SPIDER/actions/workflows/ci.yml"><img src="/assets/badges/ci-spider.svg" alt="CI" /></a></td>
       <td><a href="https://app.codecov.io/gh/FormingWorlds/SPIDER"><img src="/assets/badges/coverage-spider.svg" alt="coverage" /></a></td>
     </tr>


### PR DESCRIPTION
**What this does**: Points the SPIDER unit and integration badges on the validation page at SPIDER's new per-tier test-count files, so the breakdown shows the real tier counts (19 unit, 3 integration) instead of the fast and nightly suite counts that stood in for them.

**Why**: SPIDER now publishes tests-unit.json, tests-smoke.json, and tests-integration.json on its badges branch, so the stand-in mapping is no longer needed.

**Changes**:

- data/test_counts.yml: SPIDER markers read tests-unit.json and tests-integration.json.

- src/pages/validation.astro: the two breakdown badge links point at the per-tier JSON files.

**Testing**: Curl-verified all three per-tier endpoints and both GitHub blob links, regenerated the badges (unit renders 19, integration 3, total unchanged at 64), and ran a full site build.