### PR TITLE
Update CI actions to versions that run on Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,14 +22,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -41,4 +41,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/refresh-coverage-badges.yml
+++ b/.github/workflows/refresh-coverage-badges.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## What this does

Updates the GitHub Actions used by the build-and-deploy and coverage-badge workflows to their current major versions, so they run on Node 24 instead of the retiring Node 20 runtime.

## Why

GitHub is removing Node 20 as an action runtime. Until this change the pinned action versions still targeted Node 20, so every workflow run printed a deprecation warning while GitHub forced the actions onto Node 24. Moving to the current majors removes the warning and keeps the workflows on a supported runtime.

## Changes

- deploy: checkout v4 to v7, setup-node v4 to v7, upload-pages-artifact v3 to v5, deploy-pages v4 to v5.
- coverage badges: checkout v4 to v7, setup-python v5 to v6.

## Testing

- Confirmed against each action's `action.yml` that the current majors run on Node 24.
- Confirmed the Pages `path` input and the deploy `page_url` output are unchanged across the bump, so the publish step behaves the same.
- Both workflow files parse as valid YAML.
- The deploy runs on merge to main; the publish run is watched to completion to confirm the site still builds and deploys.
