### PR TITLE
Add Reflation ApJL paper to the publications list

### DIFF
--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -130,6 +130,23 @@ document.addEventListener('DOMContentLoaded', function() {
 
   <div class="pub-entry">
     <p class="pub-title">
+      <a href="https://arxiv.org/abs/2607.13793">Reflation: redox-driven atmospheric inflation as tracer of super-Earth geochemistry</a>
+    </p>
+    <p class="pub-authors">Cesario, Lorenzo; Lichtenberg, Tim; Attia, Mara; Nicholls, Harrison; Kisvardai, Imre; Changeat, Quentin</p>
+    <p class="pub-venue">The Astrophysical Journal Letters, in press (2026)</p>
+    <p class="pub-summary">Highly irradiated super-Earths steadily lose their atmospheres to escape, but this study finds that a chemically reduced mantle can temporarily reverse that trend. As escape strips volatiles away, continued outgassing converts water dissolved in the magma ocean into H<sub>2</sub>, driving a late-stage switch from carbon-dominated to hydrogen-dominated gas that re-inflates the atmosphere and lowers the planet's bulk density by up to 60%, hundreds of millions to billions of years after formation. The authors term this "reflation"; oxidised, Earth-like mantles instead buffer their atmospheres and deflate monotonically, so the signature could trace a super-Earth's interior redox state and formation history from population-level radius measurements.</p>
+    <details class="pub-abstract">
+      <summary>Abstract</summary>
+      <p>We demonstrate that the redox-sensitivity of mantle outgassing can trigger transient episodes of atmospheric re-inflation in highly irradiated and geochemically-reduced super-Earths, a mechanism we term reflation. Mantle redox governs the outgassing and speciation of CHONS volatiles, setting the background secondary atmospheric composition during extended photoevaporation at highly irradiated conditions. Using simulations of the coupled atmosphere-interior evolution of irradiated super-Earths, we illustrate that reduced mantles close to the iron-wustite buffer initially produce CO-dominated atmospheres. Hydrodynamic escape continuously removes volatiles while outgassing from the melt replenishes the atmosphere with H₂, converted from H₂O dissolved in the underlying magma ocean. This leads to a late-stage transition from C- to H-dominated gas that transiently re-inflates super-Earth atmospheres and decreases their bulk densities by up to ~60% between several hundreds of Myr to Gyr after their formation, prior to complete atmospheric erosion by photoevaporation. In contrast, oxidised mantles, closer to Earth-like geochemistry, strongly buffer their atmospheric composition while exposed to hydrodynamic escape, producing monotonic radius deflation. Reflation events are triggered by geochemically-reduced mantles, intermediate escape efficiencies, high irradiation, and initial water inventories ≳ 5 Earth oceans. This redox-dependent evolutionary divergence hinges on the sensitive feedback between interior and atmospheric evolution serving as a potential tracer of historical geochemical state. Population-level reflation signatures of close-in super-Earths may thus serve as tracers of interior geochemistry and formation conditions.</p>
+    </details>
+    <div class="pub-links">
+      <a href="https://scixplorer.org/abs/2026arXiv260713793C">SciX</a>
+      <a href="https://arxiv.org/abs/2607.13793">arXiv</a>
+    </div>
+  </div>
+
+  <div class="pub-entry">
+    <p class="pub-title">
       <a href="https://arxiv.org/abs/2606.20249">Geophysical and atmospheric implications of <i>f</i>O<sub>2</sub>-dependent melting on rocky exoplanets</a>
     </p>
     <p class="pub-authors">Sastre, Mariana; Lichtenberg, Tim; Soucasse, Laurent; Bower, Dan J.; Nicholls, Harrison; Kamp, Inga</p>


### PR DESCRIPTION
**What this does**: Adds the accepted Astrophysical Journal Letters paper "Reflation: redox-driven atmospheric inflation as tracer of super-Earth geochemistry" (Cesario et al.) to the Publications page.

**Why**: The paper develops results with the PROTEUS framework and belongs on the umbrella site's publication list.

**Changes**:
- New entry at the top of the Published section of `src/pages/publications.astro`, ordered newest-first (arXiv 2607, above the June 2606 entry).
- Full author list, an in-press ApJL venue line, a plain-language summary, the paper abstract, and SciX and arXiv links. No journal DOI exists yet, so the link row is SciX and arXiv only, matching the other in-press entry on the page.

**Testing**: `npm run build` completes cleanly and the entry renders correctly on the built `/publications/` page. The arXiv link and identifier were confirmed against the arXiv abstract page; the SciX link uses the standard bibcode pattern and will resolve once the record is indexed.