### PR TITLE
Add Panagiotou and Postolec papers to publications

### DIFF
--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -109,6 +109,23 @@ document.addEventListener('DOMContentLoaded', function() {
 
   <div class="pub-entry">
     <p class="pub-title">
+      <a href="https://arxiv.org/abs/2607.15204">Sulfur photochemistry observationally traces mantle redox states of rocky planets</a>
+    </p>
+    <p class="pub-authors">Panagiotou, Ioannis; Lichtenberg, Tim; Tsai, Shang-Min; Nicholls, Harrison</p>
+    <p class="pub-venue">Submitted to Astronomy &amp; Astrophysics (2026)</p>
+    <p class="pub-summary">Gases rising from a rocky planet's molten interior are reworked by starlight high in the atmosphere, raising the question of whether that chemistry erases any trace of the interior below. This study finds that the interior still sets the atmosphere's bulk make-up, but starlight strongly boosts sulfur dioxide when the mantle is chemically intermediate or oxidised, printing absorption features near 4 micrometres and again between 7 and 9 micrometres. Those features are within JWST's reach, so sulfur offers a practical way to read the chemistry of a planet's hidden interior from its atmosphere.</p>
+    <details class="pub-abstract">
+      <summary>Abstract</summary>
+      <p>Volatile outgassing from planetary interiors controls the composition of rocky exoplanets' secondary atmospheres. However, observations indicate that disequilibrium processes, such as photochemistry and vertical transport, can strongly alter the chemical structure of Hot Jupiters. Which process dominates under different types of rocky planets, and how outgassing and photochemistry jointly determine the atmospheric composition, remain open questions. Sulfur species are promising tracers of interior-atmosphere coupling because their atmospheric abundances are sensitive to both mantle redox state and stellar irradiation. The PROTEUS planetary interior-atmosphere evolution modelling framework is coupled to two chemical models, FastChem and VULCAN, for post-processed chemistry calculations. We run a grid of planetary evolution simulations spanning diverse mantle redox states, instellation fluxes, and Solar versus M-star host-star spectra. For each case, we compare atmospheric compositions under thermochemical equilibrium, only vertical transport, and vertical transport plus photochemistry. The bulk atmospheric composition remains controlled by the redox state of the mantle and outgassing history, even when disequilibrium chemistry is included. Reduced mantles produce atmospheres rich in H<sub>2</sub>, and oxidised mantles are dominated by CO<sub>2</sub>. Photochemistry affects the upper atmosphere, strongly depleting neutral volatiles and enhancing radicals, especially for highly irradiated cases. SO<sub>2</sub> is strongly enhanced at intermediate-to-oxidised redox states. Synthetic emission spectra show that photochemical SO<sub>2</sub> can generate absorption features at 4 μm and at 7.3 / 8.7 μm, reaching ~60 ppm and ~100 ppm, before sequentially returning to the outgassed signatures of ~30 ppm and ~50 ppm for the oxidised mantle redox state. These signatures are detectable with JWST, motivating targeted observational campaigns.</p>
+    </details>
+    <div class="pub-links">
+      <a href="https://scixplorer.org/abs/2026arXiv260715204P">SciX</a>
+      <a href="https://arxiv.org/abs/2607.15204">arXiv</a>
+    </div>
+  </div>
+
+  <div class="pub-entry">
+    <p class="pub-title">
       <a href="https://arxiv.org/abs/2606.24757">Coupled atmospHere Interior modeL Intercomparison (CHILI). I. Evolutionary modelling: primordial magma oceans of Earth and Venus</a>
     </p>
     <p class="pub-authors">Nicholls, Harrison; Krissansen-Totton, Joshua; Lichtenberg, Tim; Schaefer, Laura; Hamano, Keiko; Maurice, Maxime; Samuel, Henri; Papesh, Alexandra; Ortiz-Quintana, Carlos; Perez, Junellie; Miguel, Yamila; Sergeev, Denis; Baumeister, Philipp; Dash, Spanan; Janssen, Leoni; Keathley, Jonathan; de Larminat, Alexandre; Marcq, Emmanuel; Noack, Lena; Pelissard, Hugo; Peng, Bo; Postolec, Emma; Ramirez, Ramses; Sastre, Mariana; Zorzi, Andrea</p>
@@ -127,6 +144,23 @@ document.addEventListener('DOMContentLoaded', function() {
 
 <div class="pub-section">
   <h2 class="section-label">Published</h2>
+
+  <div class="pub-entry">
+    <p class="pub-title">
+      <a href="https://arxiv.org/abs/2607.15011">Atmospheric evolution through outgassing and escape on young molten rocky exoplanets</a>
+    </p>
+    <p class="pub-authors">Postolec, Emma; Lichtenberg, Tim; Nicholls, Harrison; Soucasse, Laurent; van der Tak, Floris</p>
+    <p class="pub-venue">Astronomy &amp; Astrophysics, in press (2026)</p>
+    <p class="pub-summary">On a newly formed rocky planet, a magma ocean keeps breathing out gas while the young star strips gas away. This study adds atmospheric escape to PROTEUS and follows that contest across many orbits, interior chemistries, and starting volatile budgets: escape weakens the atmosphere's greenhouse blanket, so the magma ocean freezes sooner, and the surviving gas ends up chemically sorted, because some species dissolve into magma more readily than others. Earth-mass planets keep their atmospheres as long as losses stay moderate, with outcomes spanning bare rock to thick hydrogen- or sulfur-rich envelopes.</p>
+    <details class="pub-abstract">
+      <summary>Abstract</summary>
+      <p>The earliest rocky planet atmospheres are shaped by competition between initial volatile inventories and atmospheric escape. On young magma ocean planets, outgassing competes with atmospheric escape, controlling volatile retention and atmospheric evolution. We investigate how atmospheric escape and replenishment via outgassing during magma ocean crystallization shape rocky planet atmospheres. We extend a coupled interior-atmosphere model to simulate rocky planet evolution during the magma ocean era by incorporating an energy-limited atmospheric escape module. Comparing radiative-convective and prescribed-convective atmospheres, we quantify how atmospheric energy transport affects escape. We explore a wide range of orbital separations, escape efficiencies, oxidation states, and initial volatile inventories to identify regimes where sustained magma-ocean outgassing or escape dominates. We estimate atmospheric loss and compositions for young rocky planets around Sun-like and M-dwarf stars over geologic timescales. Atmospheric escape shortens magma ocean lifetimes by weakening greenhouse insulation. Radiative-convective atmospheres reduce solidification timescales compared to purely convective cases. Volatile dissolution into the magma ocean interacts with escape to chemically fractionate the planetary volatile budget over time by retaining more soluble species. For Earth-mass planets, atmospheres survive if loss rates remain moderate. Mantle redox state remains a key control on retained atmospheric composition: high oxygen fugacity (<i>f</i>O<sub>2</sub>) yields heavier, H<sub>2</sub>O- and CO<sub>2</sub>-rich atmospheres, while low <i>f</i>O<sub>2</sub> produces light, H<sub>2</sub>- or CO-dominated atmospheres, consistent with previous studies. Orbital separation, initial volatile inventory, and stellar type produce diverse evolutionary pathways, from bare rocky planets to magma oceans with thick atmospheres, ranging from H<sub>2</sub>- to SO<sub>2</sub>-dominated.</p>
+    </details>
+    <div class="pub-links">
+      <a href="https://scixplorer.org/abs/2026arXiv260715011P">SciX</a>
+      <a href="https://arxiv.org/abs/2607.15011">arXiv</a>
+    </div>
+  </div>
 
   <div class="pub-entry">
     <p class="pub-title">


### PR DESCRIPTION
**What this does**

Adds the two PROTEUS papers that went up on arXiv today to the publications page: Panagiotou et al. on sulfur photochemistry as a tracer of mantle redox state, and Postolec et al. on outgassing versus escape on young molten rocky planets.

**Why**

Both are new, both use PROTEUS, and the page should reflect them.

**Changes**

- `src/pages/publications.astro`: Panagiotou et al. added at the top of Preprints, listed as submitted to Astronomy & Astrophysics. The paper couples PROTEUS to FastChem and VULCAN and finds JWST-detectable SO2 features that track mantle redox state.
- `src/pages/publications.astro`: Postolec et al. added at the top of Published as Astronomy & Astrophysics, in press, since it is accepted. This matches how the other accepted papers on the page are listed. The paper adds energy-limited atmospheric escape to PROTEUS.

**Testing**

- `npm run build` succeeds; both entries render correctly, with subscripts and micrometre symbols coming through as intended.
- Title, author list and order, and both abstracts checked against the arXiv API. The abstracts are the arXiv text verbatim, with subscripts and micrometre symbols restored.
- Both summaries are within the length limit set by the Reflation entry (93 and 92 words against a 98-word ceiling, three sentences each).
- The diff is additive only: 34 insertions, no deletions, no existing entry touched.

**One thing to watch**

The SciX links use bibcodes built from the usual rule (`2026arXiv` + the arXiv id without the dot + the first author's initial), which matches every existing entry. I could not confirm they resolve, because ADS lags about a day behind on indexing and both papers went up yesterday. Worth a click once ADS catches up.