### PR TITLE
Give the badge build an authenticated API budget

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,11 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # The build puts a token in the environment of the whole npm build, where any
+    # build-time dependency can read it, so this job holds only the scope the
+    # checkout needs. The deploy scopes stay with the deploy job.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -28,7 +33,18 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      # The badge generator reads each module's CI status from the GitHub Actions
+      # API. That data is public and needs no permission; the token is only for
+      # the rate limit. Unauthenticated calls draw on 60 per hour tied to the
+      # runner's outbound IP, which is shared with other Actions traffic and is
+      # sometimes spent before this build starts, leaving the CI badges at "n/a".
+      #
+      # The generator runs as the prebuild hook in package.json, so the token
+      # belongs on the build step: giving the generator a step of its own would
+      # leave prebuild running it a second time, unauthenticated, every build.
       - run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist


### PR DESCRIPTION
What this does
The CI badges on the validation page all show "n/a" right now. This gives the site build an authenticated budget for the GitHub API calls that produce them, so they stop depending on luck.

Why
The badge generator asks the GitHub Actions API for each module's latest run on main. The build step carried no token, so those twelve calls went out unauthenticated, and unauthenticated calls draw on 60 per hour tied to the runner's outbound IP, which is shared with other Actions traffic. Whether the build finds any budget left is a lottery. Most builds win it: of the last eight deploys only the most recent came up short. Each deploy prints its badge tally, and the split is exact.

| Deploy | Badge tally |
|---|---|
| 2026-07-17 06:53 (currently live) | `{"placeholder":12, "ok":43}` |
| Previous seven deploys | `{"ok":55}` |

Twelve placeholders, and there are exactly twelve CI badges. When the fetch fails the generator writes a neutral placeholder, which is the "n/a" now frozen on the page until the next deploy overwrites it.

I want to be straight about the limit of this: I could not reproduce the failing build. The generator collapses every failure mode into the same placeholder and records nothing about what the API actually returned, so a spent budget is the explanation most consistent with the evidence rather than a confirmed cause. What is confirmed is that an authenticated build resolves all twelve badges and no longer shares the runner's budget with anyone. Making the next occurrence diagnosable is worth a follow-up; the generator should log the status and the rate-limit headers when a call fails.

Changes
- `.github/workflows/deploy.yml`: pass the workflow token to the build step, and pin the build job to `contents: read`.

The token only lifts the rate limit. Workflow-run data is public, so no permission grants access to it. That matters for the second half of the change: the token sits in the environment of the whole npm build, where any build-time dependency can read it, and this workflow's token otherwise carries `pages: write` and `id-token: write`. A dependency that went bad could deface the published site or mint an OIDC token for this repo. Pinning the build job to `contents: read` leaves a leaked token worth close to nothing on an already-public repo. The Pages and OIDC scopes stay with the deploy job, which is the only place they are used.

Testing
Checked on real runners rather than reasoned about:

- A token holding `contents: read` alone reads `nichollsh/AGNI` (a different owner) and `FormingWorlds/PROTEUS`: both HTTP 200, limit 5000/hour as reported by the response header.
- With that token, the generator writes `{"ok":55}` and all twelve CI badges render `passing`.
- `upload-pages-artifact` still succeeds with the build job reduced to `contents: read` (artifact finalized, 5.1 MB), so the Pages deploy path is unaffected.
- The deploy job is untouched.

An earlier draft of this change also added `actions: read`. That permission is inert here: it scopes the token over this repository, and every CI query targets a different one. The probe above confirms the reads work without it, so it is not included.