### PR TITLE
Drop the redundant opening line on the publications page

### DIFF
--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -7,7 +7,7 @@ import Base from '../layouts/Base.astro';
   description="Scientific papers developing and applying the PROTEUS framework for coupled interior-atmosphere evolution of rocky exoplanets and early Earth."
   image="/assets/img/og-default.jpg"
 >
-  <p>This list covers papers that develop or make direct use of the PROTEUS code. For a continuously updated version, see the <a href="https://scixplorer.org/public-libraries/EVAJ1UgWTCy2Z7TRoSmjtQ">SciX library</a>.</p>
+  <p>For a continuously updated list, see the <a href="https://scixplorer.org/public-libraries/EVAJ1UgWTCy2Z7TRoSmjtQ">SciX library</a>.</p>
 
 <style is:global>
   .pub-section { margin-bottom: 2.5rem; }


### PR DESCRIPTION
What this does
Removes the first sentence of the intro paragraph on the publications page, and rewords the sentence that remains so it still names what it points at.

Why
The page hero already shows "Scientific papers that develop or apply the PROTEUS framework" directly under the "Publications" heading, so the intro's opening sentence repeated it two lines lower.

Removing it created a second problem worth fixing in the same breath. The old paragraph was self-contained:

> This list covers papers that develop or make direct use of the PROTEUS code. For a continuously updated version, see the SciX library.

"version" referred back to "This list". Delete the first sentence and "a continuously updated version" has nothing left to refer to, since nothing else in the page body is a list. So "version" becomes "list", which stands on its own and does not reintroduce the redundancy.

Changes
- `src/pages/publications.astro`: drop "This list covers papers that develop or make direct use of the PROTEUS code." and change "a continuously updated version" to "a continuously updated list".

The page now reads:

> **Publications**
> Scientific papers that develop or apply the PROTEUS framework
>
> For a continuously updated list, see the SciX library.

Testing
Built the site and checked the rendered `dist/publications/index.html`: the hero subtitle renders visibly as the page lede (so the removed sentence really was a duplicate of on-page text, not of metadata), the SciX link is intact, and the removed sentence is gone. Inclusion criteria survive in the subtitle, which carries the same meaning as the deleted sentence.