### PR TITLE
Add Morrigan as an accretion module across the site

### DIFF
--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -185,8 +185,8 @@ in_development:
     repo: Morrigan
     workflow: tests.yaml
     ci_label: CI
-    total: 44
-    breakdown: "31 unit, 13 integration"
+    total: 39
+    breakdown: "26 unit, 13 integration"
 
   - name: Obliqua
     owner: FormingWorlds

--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -16,8 +16,10 @@
 #                    must be on Codecov for the figure to populate. After adding a
 #                    module, run the "Refresh coverage badges" workflow once so
 #                    the endpoint exists before the badge renders.
-#   total          Static total test count (text or number). Shown when no
-#                    `total_endpoint` is provided.
+#   total          Static total test count (text or number), recorded here and
+#                    written as plain text into the module's row on the
+#                    validation page. Used when the module publishes no
+#                    `total_endpoint`; the badge script does not read it.
 #   total_endpoint Optional. Path of the shields.io-compatible JSON file,
 #                    relative to `badge_branch` (e.g. "tests-total.json" at the
 #                    root of a badges branch, or ".github/badges/tests-total.json"
@@ -32,8 +34,12 @@
 #                    `total_endpoint` and `markers` only. The CI badge always
 #                    tracks main; the coverage badge is read from this site's own
 #                    `badges` branch (see `has_codecov`).
-#   breakdown      Optional. Plain-text marker breakdown ("816 unit, ...").
-#                    Used until per-marker endpoint files are published.
+#   breakdown      Optional. Plain-text marker breakdown ("816 unit, ..."),
+#                    recorded here and written into the row beside `total`.
+#                    Used when the module publishes no `markers`. Keep it to
+#                    the two public categories, unit and integration, folding
+#                    any extra tier into integration, so the text agrees with
+#                    what the marker badges show once they go live.
 #   markers        Optional. Map of marker name to JSON path (relative to
 #                    `badge_branch`) or full https URL; when set, each marker
 #                    renders as a live shields.io badge in place of `breakdown`.
@@ -173,6 +179,14 @@ in_development:
     markers:
       unit: tests-unit.json
       integration: tests-integration.json
+
+  - name: Morrigan
+    owner: FormingWorlds
+    repo: Morrigan
+    workflow: tests.yaml
+    ci_label: CI
+    total: 44
+    breakdown: "31 unit, 13 integration"
 
   - name: Obliqua
     owner: FormingWorlds

--- a/data/test_counts.yml
+++ b/data/test_counts.yml
@@ -168,6 +168,18 @@ mature:
       unit: tests-unit.json
       integration: tests-integration.json
 
+  - name: Morrigan
+    owner: FormingWorlds
+    repo: Morrigan
+    workflow: tests.yaml
+    ci_label: CI
+    has_codecov: true
+    total_endpoint: tests-total.json
+    badge_branch: badges
+    markers:
+      unit: tests-unit.json
+      integration: tests-integration.json
+
 in_development:
   - name: VULCAN
     owner: FormingWorlds
@@ -179,14 +191,6 @@ in_development:
     markers:
       unit: tests-unit.json
       integration: tests-integration.json
-
-  - name: Morrigan
-    owner: FormingWorlds
-    repo: Morrigan
-    workflow: tests.yaml
-    ci_label: CI
-    total: 39
-    breakdown: "26 unit, 13 integration"
 
   - name: Obliqua
     owner: FormingWorlds

--- a/public/assets/styles/site.css
+++ b/public/assets/styles/site.css
@@ -1,4 +1,4 @@
-/* PROTEUS website — shared chrome (Thermocline v1.1). Pairs with tokens.css.
+/* PROTEUS website — shared chrome (Thermocline v1.2). Pairs with tokens.css.
    The chrome section mirrors templates/web/site.css in
    FormingWorlds/proteus-visual-language; site-specific extensions follow the
    marked divider below. */
@@ -164,6 +164,7 @@ html { overflow-x: hidden; overflow-x: clip; }
 .dom-chem { background: var(--pt-dom-chem); }
 .dom-atmos { background: var(--pt-dom-atmos); }
 .dom-stellar { background: var(--pt-dom-stellar); }
+.dom-accretion { background: var(--pt-dom-accretion); }
 
 /* ---------- brand lockup (Lockup.astro) ---------- */
 /* The wordmark with the phase glyph as the O plus the "framework" tag. The

--- a/public/assets/styles/tokens.css
+++ b/public/assets/styles/tokens.css
@@ -1,5 +1,5 @@
 /* ============================================================
-   PROTEUS FRAMEWORK — THERMOCLINE DESIGN TOKENS  v1.1
+   PROTEUS FRAMEWORK — THERMOCLINE DESIGN TOKENS  v1.2
    Magma · Void · Ocean — dark-first, instrument-grade
    Fonts: Sora / Instrument Sans / Spline Sans Mono
    ============================================================ */
@@ -55,6 +55,7 @@
   --pt-dom-chem:       #1B6FA8;  /* VULCAN, ZEPHYRUS */
   --pt-dom-atmos:      #4FA3D9;  /* AGNI, JANUS */
   --pt-dom-stellar:    #E0A32E;  /* MORS — solar gold, deepens on light for contrast */
+  --pt-dom-accretion:  #A38F7A;  /* Morrigan, clay; sits clear of the reds and the blues */
 
   /* ——— SEMANTIC ——— */
   --pt-positive: #2E8B57;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -83,6 +83,7 @@ const jsonLd = {
         aragog: '/aragog/',
         calliope: '/CALLIOPE/',
         janus: '/JANUS/',
+        morrigan: '/Morrigan/',
         mors: '/MORS/',
         obliqua: '/Obliqua/',
         proteus: '/PROTEUS/',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,10 +14,11 @@ const overviewModules = [
   { name: 'MORS', brief: 'Stellar evolution tracks', domain: 'stellar' },
   { name: 'LovePy / Obliqua', brief: 'Tidal dissipation and heating', domain: 'tidal' },
   { name: 'Zalmoxis', brief: 'Planetary interior structure', domain: 'interior' },
+  { name: 'Morrigan', brief: 'Giant impacts and protoplanet accretion', domain: 'accretion' },
 ];
 
 // A typo'd domain would render an invisible swatch; fail the build instead.
-const knownDomains = ['interior', 'outgassing', 'tidal', 'chem', 'atmos', 'stellar'];
+const knownDomains = ['interior', 'outgassing', 'tidal', 'chem', 'atmos', 'stellar', 'accretion'];
 for (const m of overviewModules) {
   if (!knownDomains.includes(m.domain)) {
     throw new Error(`Unknown module domain "${m.domain}" for ${m.name}`);

--- a/src/pages/license.astro
+++ b/src/pages/license.astro
@@ -84,7 +84,7 @@ Representative examples across the ecosystem:</p>
     <tr><th>License</th><th>Type</th><th>Examples</th></tr>
   </thead>
   <tbody>
-    <tr><td>Apache 2.0</td><td>Permissive (with patent grant)</td><td>PROTEUS, AGNI, CALLIOPE, JANUS, ZEPHYRUS, Zalmoxis</td></tr>
+    <tr><td>Apache 2.0</td><td>Permissive (with patent grant)</td><td>PROTEUS, AGNI, CALLIOPE, JANUS, ZEPHYRUS, Zalmoxis, Morrigan</td></tr>
     <tr><td>MIT</td><td>Permissive</td><td>MORS</td></tr>
     <tr><td>BSD 3-Clause</td><td>Permissive</td><td>SOCRATES</td></tr>
     <tr><td>GPL-3.0</td><td>Strong copyleft</td><td>VULCAN, FastChem, atmodeller, SPIDER, aragog</td></tr>

--- a/src/pages/modules.astro
+++ b/src/pages/modules.astro
@@ -196,7 +196,7 @@ import Base from '../layouts/Base.astro';
     <div class="module-accent dom-accretion"></div>
     <div class="module-info">
       <p class="module-name">Morrigan</p>
-      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses and orbits of the bodies that survive. Every impact is reported with its speed and the escape velocity of the pair, the two numbers a separate calculation needs to work out what a collision strips away. It runs on its own for now; coupling it into a PROTEUS run is in development.</p>
+      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses and orbits of the bodies that survive. Each merger is recorded with the two masses involved, the collision speed, and the orbit the merged body ends on. It runs on its own for now; coupling it into a PROTEUS run is in development.</p>
     </div>
     <div class="module-link"><a href="https://proteus-framework.org/Morrigan/" target="_blank" rel="noopener noreferrer">Docs ↗</a></div>
   </div>

--- a/src/pages/modules.astro
+++ b/src/pages/modules.astro
@@ -196,7 +196,7 @@ import Base from '../layouts/Base.astro';
     <div class="module-accent dom-accretion"></div>
     <div class="module-info">
       <p class="module-name">Morrigan</p>
-      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses and orbits of the bodies that survive. Collisions conserve mass exactly, and the geometry of each impact is recorded so that any atmosphere lost in it can be computed separately. It runs on its own: the coupling that would let it hand a PROTEUS run its starting planets is still in development.</p>
+      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses and orbits of the bodies that survive. Every impact is reported with its speed and the escape velocity of the pair, the two numbers a separate calculation needs to work out what a collision strips away. It runs on its own for now; coupling it into a PROTEUS run is in development.</p>
     </div>
     <div class="module-link"><a href="https://proteus-framework.org/Morrigan/" target="_blank" rel="noopener noreferrer">Docs ↗</a></div>
   </div>

--- a/src/pages/modules.astro
+++ b/src/pages/modules.astro
@@ -196,7 +196,7 @@ import Base from '../layouts/Base.astro';
     <div class="module-accent dom-accretion"></div>
     <div class="module-info">
       <p class="module-name">Morrigan</p>
-      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses, orbits, and atmospheres of the bodies that survive. It runs on its own: the coupling that would let it hand a PROTEUS run its starting planets is still in development.</p>
+      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses and orbits of the bodies that survive. Collisions conserve mass exactly, and the geometry of each impact is recorded so that any atmosphere lost in it can be computed separately. It runs on its own: the coupling that would let it hand a PROTEUS run its starting planets is still in development.</p>
     </div>
     <div class="module-link"><a href="https://proteus-framework.org/Morrigan/" target="_blank" rel="noopener noreferrer">Docs ↗</a></div>
   </div>

--- a/src/pages/modules.astro
+++ b/src/pages/modules.astro
@@ -196,7 +196,7 @@ import Base from '../layouts/Base.astro';
     <div class="module-accent dom-accretion"></div>
     <div class="module-info">
       <p class="module-name">Morrigan</p>
-      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses, orbits, and atmospheres of the bodies that survive.</p>
+      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses, orbits, and atmospheres of the bodies that survive. It runs on its own: the coupling that would let it hand a PROTEUS run its starting planets is still in development.</p>
     </div>
     <div class="module-link"><a href="https://proteus-framework.org/Morrigan/" target="_blank" rel="noopener noreferrer">Docs ↗</a></div>
   </div>

--- a/src/pages/modules.astro
+++ b/src/pages/modules.astro
@@ -196,7 +196,7 @@ import Base from '../layouts/Base.astro';
     <div class="module-accent dom-accretion"></div>
     <div class="module-info">
       <p class="module-name">Morrigan</p>
-      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses and orbits of the bodies that survive. Each merger is recorded with the two masses involved, the collision speed, and the orbit the merged body ends on. It runs on its own for now; coupling it into a PROTEUS run is in development.</p>
+      <p class="module-desc">Follows a system of protoplanets through the giant impacts and scattering by which they accrete, recording the masses, collision speed, and orbit of each merger, which set the starting state for a coupled PROTEUS run.</p>
     </div>
     <div class="module-link"><a href="https://proteus-framework.org/Morrigan/" target="_blank" rel="noopener noreferrer">Docs ↗</a></div>
   </div>

--- a/src/pages/modules.astro
+++ b/src/pages/modules.astro
@@ -5,10 +5,10 @@ import Base from '../layouts/Base.astro';
 <Base
   title="Modules within PROTEUS"
   subtitle="Explore the modular components of the PROTEUS framework"
-  description="Modular components of the PROTEUS framework: atmosphere, mantle, outgassing, photochemistry, escape, stellar evolution, tides, and interior structure models."
+  description="Modular components of the PROTEUS framework: atmosphere, mantle, outgassing, photochemistry, escape, stellar evolution, tides, interior structure, and accretion models."
   image="/assets/img/og-default.jpg"
 >
-      <p>Planetary evolution involves tightly coupled physical processes: radiative transfer in the atmosphere, convection and solidification in the mantle, volatile exchange between interior and surface reservoirs, chemical reactions, atmospheric escape, stellar irradiation, and tidal dissipation. No single code can treat all of these from first principles at once.</p>
+      <p>Planetary evolution involves tightly coupled physical processes: giant impacts during accretion, radiative transfer in the atmosphere, convection and solidification in the mantle, volatile exchange between interior and surface reservoirs, chemical reactions, atmospheric escape, stellar irradiation, and tidal dissipation. No single code can treat all of these from first principles at once.</p>
 
 <p>PROTEUS addresses this by adopting a modular architecture. Each physical domain is handled by a dedicated module that can be developed, tested, and validated independently. The PROTEUS coupler orchestrates the exchange of boundary conditions between modules at each time step, so that the full system evolves self-consistently. This design makes it straightforward to swap one atmosphere model for another, to enable or disable tidal heating, or to plug in a new outgassing parameterisation without rewriting the rest of the framework.</p>
 
@@ -187,6 +187,18 @@ import Base from '../layouts/Base.astro';
       <p class="module-desc">Extends tidal modelling to bodies with both solid and liquid layers, computing dissipation across multiple rheological phases and coupling tidal heat to the interior energy budget.</p>
     </div>
     <div class="module-link"><a href="https://proteus-framework.org/Obliqua/" target="_blank" rel="noopener noreferrer">Docs ↗</a></div>
+  </div>
+</div>
+
+<div class="module-group">
+  <h2 class="section-label">Accretion</h2>
+  <div class="module-card">
+    <div class="module-accent dom-accretion"></div>
+    <div class="module-info">
+      <p class="module-name">Morrigan</p>
+      <p class="module-desc">Follows a system of protoplanets through the giant impacts and gravitational scattering of its final assembly, tracking how each collision changes the masses, orbits, and atmospheres of the bodies that survive.</p>
+    </div>
+    <div class="module-link"><a href="https://proteus-framework.org/Morrigan/" target="_blank" rel="noopener noreferrer">Docs ↗</a></div>
   </div>
 </div>
 </Base>

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -447,6 +447,12 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td><a href="https://github.com/FormingWorlds/VULCAN/actions/workflows/tests.yaml"><img src="/assets/badges/ci-vulcan.svg" alt="CI" /></a></td>
     </tr>
     <tr>
+      <td class="module-name"><a href="https://github.com/FormingWorlds/Morrigan">Morrigan</a></td>
+      <td class="test-count">44</td>
+      <td class="test-breakdown">31 unit, 13 integration</td>
+      <td><a href="https://github.com/FormingWorlds/Morrigan/actions/workflows/tests.yaml"><img src="/assets/badges/ci-morrigan.svg" alt="CI" /></a></td>
+    </tr>
+    <tr>
       <td class="module-name"><a href="https://github.com/FormingWorlds/Obliqua">Obliqua</a></td>
       <td class="test-count">custom suite</td>
       <td class="test-breakdown">Hand-written Julia validation runner, Test.jl migration planned</td>

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -417,6 +417,13 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td><a href="https://github.com/FormingWorlds/JANUS/actions/workflows/tests.yaml"><img src="/assets/badges/ci-janus.svg" alt="CI" /></a></td>
       <td><a href="https://app.codecov.io/gh/FormingWorlds/JANUS"><img src="/assets/badges/coverage-janus.svg" alt="coverage" /></a></td>
     </tr>
+    <tr>
+      <td class="module-name"><a href="https://github.com/FormingWorlds/Morrigan">Morrigan</a></td>
+      <td class="test-count"><a href="https://github.com/FormingWorlds/Morrigan/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-morrigan.svg" alt="tests" /></a></td>
+      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/Morrigan/blob/badges/tests-unit.json"><img src="/assets/badges/tests-unit-morrigan.svg" alt="unit" /></a><a href="https://github.com/FormingWorlds/Morrigan/blob/badges/tests-integration.json"><img src="/assets/badges/tests-integration-morrigan.svg" alt="integration" /></a></td>
+      <td><a href="https://github.com/FormingWorlds/Morrigan/actions/workflows/tests.yaml"><img src="/assets/badges/ci-morrigan.svg" alt="CI" /></a></td>
+      <td><a href="https://app.codecov.io/gh/FormingWorlds/Morrigan"><img src="/assets/badges/coverage-morrigan.svg" alt="coverage" /></a></td>
+    </tr>
 
   </tbody>
 </table>
@@ -445,12 +452,6 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
       <td class="test-count"><a href="https://github.com/FormingWorlds/VULCAN/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-vulcan.svg" alt="tests" /></a></td>
       <td class="test-breakdown"><a href="https://github.com/FormingWorlds/VULCAN/blob/badges/tests-unit.json"><img src="/assets/badges/tests-unit-vulcan.svg" alt="unit" /></a><a href="https://github.com/FormingWorlds/VULCAN/blob/badges/tests-integration.json"><img src="/assets/badges/tests-integration-vulcan.svg" alt="integration" /></a></td>
       <td><a href="https://github.com/FormingWorlds/VULCAN/actions/workflows/tests.yaml"><img src="/assets/badges/ci-vulcan.svg" alt="CI" /></a></td>
-    </tr>
-    <tr>
-      <td class="module-name"><a href="https://github.com/FormingWorlds/Morrigan">Morrigan</a></td>
-      <td class="test-count">39</td>
-      <td class="test-breakdown">26 unit, 13 integration</td>
-      <td><a href="https://github.com/FormingWorlds/Morrigan/actions/workflows/tests.yaml"><img src="/assets/badges/ci-morrigan.svg" alt="CI" /></a></td>
     </tr>
     <tr>
       <td class="module-name"><a href="https://github.com/FormingWorlds/Obliqua">Obliqua</a></td>

--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -448,8 +448,8 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
     </tr>
     <tr>
       <td class="module-name"><a href="https://github.com/FormingWorlds/Morrigan">Morrigan</a></td>
-      <td class="test-count">44</td>
-      <td class="test-breakdown">31 unit, 13 integration</td>
+      <td class="test-count">39</td>
+      <td class="test-breakdown">26 unit, 13 integration</td>
       <td><a href="https://github.com/FormingWorlds/Morrigan/actions/workflows/tests.yaml"><img src="/assets/badges/ci-morrigan.svg" alt="CI" /></a></td>
     </tr>
     <tr>


### PR DESCRIPTION
## What this does

Adds Morrigan to the site as a full module, under a new accretion domain with its own colour, and gives it a row on the validation page.

## Why

Morrigan is the dynamical evolution module: it follows a system of protoplanets through the giant impacts and gravitational scattering of final assembly. None of the six existing physical domains fits it, so accretion becomes the seventh, and the module gets the same treatment as every other one: a homepage entry, a card on the modules page, a licence-table mention, and a validation row.

The accretion colour is clay `#A38F7A`, added upstream in Thermocline v1.2. It holds a wide colour-blind separation from the other six domain colours on both the dark and the light surface set, so a reader can still tell a Morrigan series from a SPIDER or a MORS one.

Morrigan goes in the "Suites in development" table rather than the mature one because only its CI badge can currently resolve. It publishes no badge endpoints on a `badges` branch yet, and it is not activated on Codecov, so a mature row's five live badges are not available. A broken badge on the front page is worse than a missing one.

## Changes

- `public/assets/styles/tokens.css`: re-vendored from proteus-visual-language at v1.2, which adds `--pt-dom-accretion`. This file is vendored verbatim, so the only delta is the version header and the new declaration.
- `public/assets/styles/site.css`: `.dom-accretion` alongside the other six domain classes, and the mirrored chrome header follows the upstream version bump.
- `src/pages/index.astro`: Morrigan in the homepage module overview, and `accretion` added to the domain allowlist that fails the build on a typo'd domain.
- `src/pages/modules.astro`: an Accretion section with the Morrigan card, plus accretion named in the opening list of coupled processes and in the page description.
- `src/pages/license.astro`: Morrigan in the Apache 2.0 row.
- `src/pages/validation.astro`: the Morrigan row, with a static test count and a CI badge linking to the workflow.
- `data/test_counts.yml`: the Morrigan entry, deliberately without `total_endpoint`, `markers`, `badge_branch`, or `has_codecov`, since none of those sources exist yet. The notes on `total` and `breakdown` now say where those values are rendered, that the badge script does not read them, and that a breakdown should keep to the two public categories.
- `src/layouts/Base.astro`: `morrigan` in the case-correction map. Without it, a request for `/morrigan` in the wrong case dead-ends instead of redirecting the way every other module does.

## Testing

- `npm run build` succeeds, 8 pages. The rendered markup carries `module-swatch dom-accretion` on the homepage and `module-accent dom-accretion` on the modules page, and the class resolves to `#A38F7A` through the vendored token.
- `npm test` passes, 7 tests, so the light and dark theme behaviour is unchanged.
- The validation row reads `Morrigan | 39 | 26 unit, 13 integration | [CI badge]`, and `morrigan: '/Morrigan/'` is present in `dist/404.html`.
- Case redirect verified against the live site: `https://proteus-framework.org/Morrigan/` returns 200 and `https://proteus-framework.org/morrigan` returns 404, which is the case the new map entry fixes.
- The count was taken from `main`, not from a branch: walking the test functions across the suite at `787f433` gives 39, marked 26 unit, 10 smoke, and 3 integration. The breakdown reads "26 unit, 13 integration" because the site's badge surface has two public categories and folds smoke into integration, which keeps the integration figure comparable with the other modules' badges.
