### PR TITLE
Update the site contact email to dev@proteus-framework.org

### DIFF
--- a/src/data/settings.js
+++ b/src/data/settings.js
@@ -10,7 +10,7 @@ export const favicons = {
   dark: '/assets/img/brand/favicon.png',
 };
 
-export const contactEmail = 'proteus_dev@formingworlds.space';
+export const contactEmail = 'dev@proteus-framework.org';
 
 // Ordered top navigation. Items with `submenuItems` render as a dropdown.
 export const menuItems = [

--- a/src/pages/license.astro
+++ b/src/pages/license.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import { contactEmail } from '../data/settings.js';
 ---
 <Base
   title="Licensing and open development"
@@ -194,7 +195,7 @@ PROTEUS exists because of the work of the wider community, and many of its modul
 We have set out our position here, and we welcome questions, corrections, and discussion.
 If you maintain a code we depend on, are considering using PROTEUS in your own work, or simply want to understand our approach better, please get in touch.</p>
 
-<p>You can reach us through <a href="https://github.com/orgs/FormingWorlds/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a>, open an issue on the relevant repository, or email <a href="mailto:proteus_dev@formingworlds.space">proteus_dev@formingworlds.space</a>.</p>
+<p>You can reach us through <a href="https://github.com/orgs/FormingWorlds/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a>, open an issue on the relevant repository, or email <a href={`mailto:${contactEmail}`}>{contactEmail}</a>.</p>
 
 <style is:global>
   table.lic-table {

--- a/src/pages/people.astro
+++ b/src/pages/people.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import { contactEmail } from '../data/settings.js';
 
 // One entry per person: display name, role, external profile link, photo in
 // public/assets/img/faces/, and three research-topic labels. The topic lists
@@ -170,7 +171,7 @@ const pastContributors = [
 ---
 <Base
   title="Meet the team"
-  subtitle='For enquiries please write an email to <a href="mailto:proteus_dev@formingworlds.space">proteus_dev@formingworlds.space</a>'
+  subtitle={`For enquiries please write an email to <a href="mailto:${contactEmail}">${contactEmail}</a>`}
   description="The PROTEUS development team: researchers and software engineers building open-source tools for rocky planet evolution."
   image="/assets/img/og-default.jpg"
 >


### PR DESCRIPTION
## What this does

Replaces the site contact email, proteus_dev@formingworlds.space, with dev@proteus-framework.org everywhere it appears: the footer's shared constant, the team page, and the licensing page.

## Why

The framework now has its own domain, and I want the contact address to live there rather than on the lab's older formingworlds.space domain.

## Changes

- `src/data/settings.js`: the `contactEmail` constant, consumed by the footer on every page.
- `src/pages/people.astro`: the team page's contact line, now importing `contactEmail` instead of hardcoding the address.
- `src/pages/license.astro`: the licensing page's contact line, same change.

## Testing

- `npm run build` and grepped the built `dist/` output: the old address is gone everywhere, and all three mailto links render with matching href and display text.
- `npm test` (Playwright): all 7 tests pass.