### PR TITLE
Link the SPIDER integration badge to the file it reports

### DIFF
--- a/src/pages/validation.astro
+++ b/src/pages/validation.astro
@@ -406,7 +406,7 @@ The PROTEUS framework and its mature submodules expose passing-tests badges and,
     <tr>
       <td class="module-name"><a href="https://github.com/FormingWorlds/SPIDER">SPIDER</a></td>
       <td class="test-count"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-total.json"><img src="/assets/badges/tests-total-spider.svg" alt="tests" /></a></td>
-      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-unit.json"><img src="/assets/badges/tests-unit-spider.svg" alt="unit" /></a><a href="https://github.com/FormingWorlds/SPIDER/tree/badges"><img src="/assets/badges/tests-integration-spider.svg" alt="integration" /></a></td>
+      <td class="test-breakdown"><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-unit.json"><img src="/assets/badges/tests-unit-spider.svg" alt="unit" /></a><a href="https://github.com/FormingWorlds/SPIDER/blob/badges/tests-integration.json"><img src="/assets/badges/tests-integration-spider.svg" alt="integration" /></a></td>
       <td><a href="https://github.com/FormingWorlds/SPIDER/actions/workflows/ci.yml"><img src="/assets/badges/ci-spider.svg" alt="CI" /></a></td>
       <td><a href="https://app.codecov.io/gh/FormingWorlds/SPIDER"><img src="/assets/badges/coverage-spider.svg" alt="coverage" /></a></td>
     </tr>


### PR DESCRIPTION
**What this does**: Points the SPIDER integration badge on the validation page at `tests-integration.json`, the file the badge reports, instead of at the badges branch listing.

**Why**: Of the twelve modules on that page whose breakdown badges are links, SPIDER's integration badge was the only one that did not reach its own endpoint. Its unit and total badges beside it both do, and AGNI and atmodeller reach theirs through gist file anchors. Nothing was broken: the badge already renders the right count, because `scripts/generate-badges.mjs` builds its URLs from `data/test_counts.yml` and never reads the hrefs on the page. This is about where clicking a badge takes you.

This is the one line that was still worth having out of #41, which is closed as superseded; the rest of that branch had already landed with the redesign.

**Changes**:

- `src/pages/validation.astro`: the SPIDER integration badge links to `blob/badges/tests-integration.json`.

**Testing**: Confirmed the new URL serves the shields endpoint (`integration tests`, 45). Checked every badge source the page depends on, not just this one: all 34 endpoints declared in `data/test_counts.yml` exist on their badge branches, and all 54 GitHub links on the validation page resolve. Ran `npm run build` and confirmed the rendered `/validation/index.html` carries the new link and that no `tree/badges` link remains anywhere on the page.
